### PR TITLE
feat(ledger-sim): capture effect origins in a side channel

### DIFF
--- a/crates/ledger-sim/src/backend_sim.rs
+++ b/crates/ledger-sim/src/backend_sim.rs
@@ -2,6 +2,7 @@
 
 use crate::effects::{Effects, Fs, Net};
 use crate::net::{Message, SimNet};
+use crate::origin::{OriginLog, OriginSource};
 use crate::seedtree::SeedTree;
 use crate::simfs::SimFs;
 use crate::time::{Clock, VirtualTime};
@@ -105,6 +106,9 @@ pub struct SimBackend {
     rng_streams: Vec<Option<SimStreamRng>>,
     /// Optional shared tick sink published to WASI virtual clocks.
     tick_sink: Option<Arc<Mutex<u64>>>,
+    /// Side channel of effect origins keyed by entry hash. Never serialized
+    /// into the journal; see [`crate::origin`].
+    origins: Mutex<OriginLog>,
 }
 
 impl SimBackend {
@@ -125,6 +129,7 @@ impl SimBackend {
             actor,
             rng_streams: Vec::new(),
             tick_sink: None,
+            origins: Mutex::new(OriginLog::default()),
         }
     }
 
@@ -162,6 +167,16 @@ impl SimBackend {
     /// Return the actor id this backend journals entries for.
     pub fn actor(&self) -> ActorId {
         self.actor
+    }
+
+    /// Snapshot the captured effect origins in append order.
+    pub fn origins_snapshot(&self) -> Vec<(Hash, OriginSource)> {
+        lock(&self.origins).snapshot()
+    }
+
+    /// Look up the origin of one journaled entry.
+    pub fn origin_of(&self, id: &Hash) -> Option<OriginSource> {
+        lock(&self.origins).get(id).cloned()
     }
 
     /// Append an entry through this backend's journaling path.
@@ -250,29 +265,30 @@ impl Effects for SimBackend {
 
 impl Net for SimBackend {
     fn send(&self, message: Message) -> bool {
-        let Some(id) = self.append(
-            EntryKind::Send,
-            [],
-            Payload::Pair {
-                left: message.to as u64,
-                right: message.payload,
-            },
-        ) else {
-            return false;
-        };
-        lock(&self.net).send(Message {
-            send_id: id,
-            ..message
-        })
+        self.send_impl(message).0
+    }
+
+    fn send_loc(&self, message: Message, at: OriginSource) -> bool {
+        let (delivered, id) = self.send_impl(message);
+        if let Some(id) = id {
+            lock(&self.origins).record(id, at);
+        }
+        delivered
     }
 
     fn recv(&self, task: usize, now: u64) -> Option<Message> {
         let message = lock(&self.net).recv_at(task, now)?;
-        self.append(
+        let id = self.append(
             EntryKind::Recv,
             [message.send_id],
             Payload::Number(message.payload),
         );
+        // Clone the origin out before re-locking: the guard from `get` lives
+        // to the end of the statement, and the mutex is not reentrant.
+        let inherited = lock(&self.origins).get(&message.send_id).cloned();
+        if let (Some(id), Some(origin)) = (id, inherited) {
+            lock(&self.origins).record(id, origin);
+        }
         Some(message)
     }
 
@@ -281,17 +297,47 @@ impl Net for SimBackend {
     }
 }
 
+impl SimBackend {
+    /// Append the Send entry and hand the message to the simulated network.
+    /// Returns delivery status plus the Send entry id when journaling worked.
+    fn send_impl(&self, message: Message) -> (bool, Option<Hash>) {
+        let Some(id) = self.append(
+            EntryKind::Send,
+            [],
+            Payload::Pair {
+                left: message.to as u64,
+                right: message.payload,
+            },
+        ) else {
+            return (false, None);
+        };
+        let delivered = lock(&self.net).send(Message {
+            send_id: id,
+            ..message
+        });
+        (delivered, Some(id))
+    }
+}
+
 impl Fs for SimBackend {
     fn write(&self, path: &str, value: u64) -> Result<Hash, JournalError> {
-        let mut journal = lock(&self.journal);
-        let mut fs = lock(&*self.fs);
-        fs.write(&mut journal, self.actor, path, value)
+        self.write_impl(path, value)
+    }
+
+    fn write_loc(&self, path: &str, value: u64, at: OriginSource) -> Result<Hash, JournalError> {
+        let id = self.write_impl(path, value)?;
+        lock(&self.origins).record(id, at);
+        Ok(id)
     }
 
     fn fsync(&self) -> Result<Hash, JournalError> {
-        let mut journal = lock(&self.journal);
-        let mut fs = lock(&*self.fs);
-        fs.fsync(&mut journal, self.actor)
+        self.fsync_impl()
+    }
+
+    fn fsync_loc(&self, at: OriginSource) -> Result<Hash, JournalError> {
+        let id = self.fsync_impl()?;
+        lock(&self.origins).record(id, at);
+        Ok(id)
     }
 
     fn read(&self, path: &str) -> Result<Option<u64>, JournalError> {
@@ -301,7 +347,33 @@ impl Fs for SimBackend {
     }
 
     fn crash(&self) {
-        self.append(
+        self.crash_impl();
+    }
+
+    fn crash_loc(&self, at: OriginSource) {
+        if let Some(id) = self.crash_impl() {
+            lock(&self.origins).record(id, at);
+        }
+    }
+}
+
+impl SimBackend {
+    fn write_impl(&self, path: &str, value: u64) -> Result<Hash, JournalError> {
+        let mut journal = lock(&self.journal);
+        let mut fs = lock(&*self.fs);
+        fs.write(&mut journal, self.actor, path, value)
+    }
+
+    fn fsync_impl(&self) -> Result<Hash, JournalError> {
+        let mut journal = lock(&self.journal);
+        let mut fs = lock(&*self.fs);
+        fs.fsync(&mut journal, self.actor)
+    }
+
+    /// Append the crash-fault entry and fold storage into the post-crash
+    /// state. Returns the entry id when journaling worked.
+    fn crash_impl(&self) -> Option<Hash> {
+        let id = self.append(
             EntryKind::Fault {
                 fault: FaultSpec::CrashState(0),
             },
@@ -309,6 +381,7 @@ impl Fs for SimBackend {
             Payload::Empty,
         );
         lock(&*self.fs).crash();
+        id
     }
 }
 

--- a/crates/ledger-sim/src/effects.rs
+++ b/crates/ledger-sim/src/effects.rs
@@ -1,7 +1,9 @@
 //! Effect boundary between the system under test and deterministic execution.
 
 use crate::net::Message;
+use crate::origin::OriginSource;
 use crate::time::Clock;
+use core::panic::Location;
 use ledger_format::{Hash, StreamId};
 use rand_core::Rng;
 
@@ -17,11 +19,32 @@ pub trait Net {
     /// Queue a message for delivery. Returns false if the link is partitioned.
     fn send(&self, message: Message) -> bool;
 
+    /// Queue a message for delivery, recording where the send came from.
+    ///
+    /// The origin lands in the session side channel keyed by the Send entry
+    /// hash; journal bytes are unchanged. The default drops the origin so
+    /// existing implementations stay correct without code changes.
+    fn send_loc(&self, message: Message, at: OriginSource) -> bool {
+        let _ = at;
+        self.send(message)
+    }
+
     /// Take the first deliverable message for `task` available at `now`.
     fn recv(&self, task: usize, now: u64) -> Option<Message>;
 
     fn has_ready_message(&self, task: usize, now: u64) -> bool;
 }
+
+/// Tracked aliases for the network boundary: same behavior, plus origin
+/// capture into the session side channel when the backend supports it.
+pub trait NetExt: Net {
+    #[track_caller]
+    fn send_tracked(&self, message: Message) -> bool {
+        self.send_loc(message, Location::caller().into())
+    }
+}
+
+impl<T: Net + ?Sized> NetExt for T {}
 
 /// Storage boundary exposed to systems under test.
 ///
@@ -32,15 +55,60 @@ pub trait Fs {
     /// Write a value to the page cache and return its journal entry id.
     fn write(&self, path: &str, value: u64) -> Result<Hash, ledger_journal::JournalError>;
 
+    /// Write with origin capture; see [`Net::send_loc`]. Default delegates.
+    fn write_loc(
+        &self,
+        path: &str,
+        value: u64,
+        at: OriginSource,
+    ) -> Result<Hash, ledger_journal::JournalError> {
+        let _ = at;
+        self.write(path, value)
+    }
+
     /// Flush all dirty page-cache entries to durable synced storage.
     fn fsync(&self) -> Result<Hash, ledger_journal::JournalError>;
+
+    /// Flush with origin capture; see [`Net::send_loc`]. Default delegates.
+    fn fsync_loc(&self, at: OriginSource) -> Result<Hash, ledger_journal::JournalError> {
+        let _ = at;
+        self.fsync()
+    }
 
     /// Read a value from page cache, recording provenance of the observed write.
     fn read(&self, path: &str) -> Result<Option<u64>, ledger_journal::JournalError>;
 
     /// Crash storage into the deterministic post-crash state.
     fn crash(&self);
+
+    /// Crash with origin capture; see [`Net::send_loc`]. Default delegates.
+    fn crash_loc(&self, at: OriginSource) {
+        let _ = at;
+        self.crash()
+    }
 }
+
+/// Tracked aliases for the storage boundary. Read is deliberately absent:
+/// its provenance entries are appended inside the fs layer, so there is no
+/// entry id observable at this boundary to key an origin against.
+pub trait FsExt: Fs {
+    #[track_caller]
+    fn write_tracked(&self, path: &str, value: u64) -> Result<Hash, ledger_journal::JournalError> {
+        self.write_loc(path, value, Location::caller().into())
+    }
+
+    #[track_caller]
+    fn fsync_tracked(&self) -> Result<Hash, ledger_journal::JournalError> {
+        self.fsync_loc(Location::caller().into())
+    }
+
+    #[track_caller]
+    fn crash_tracked(&self) {
+        self.crash_loc(Location::caller().into())
+    }
+}
+
+impl<T: Fs + ?Sized> FsExt for T {}
 
 /// Effect boundary implemented by simulation and production backends.
 ///

--- a/crates/ledger-sim/src/lib.rs
+++ b/crates/ledger-sim/src/lib.rs
@@ -16,6 +16,7 @@ mod dpor;
 mod effects;
 mod executor;
 mod net;
+mod origin;
 mod runtime;
 mod scheduler;
 mod seedtree;
@@ -37,9 +38,10 @@ pub use config_canonical::{
     to_canonical_bytes,
 };
 pub use dpor::{DporConfig, DporReport, DporRun, run_dpor};
-pub use effects::{Effects, Fs, Net, TaskId};
+pub use effects::{Effects, Fs, FsExt, Net, NetExt, TaskId};
 pub use executor::{Boundary, Executor};
 pub use net::{DnsTable, LinkConfig, Message, SimNet, backoff, backoff_jittered};
+pub use origin::{EffectOrigin, OriginSource};
 pub use runtime::{
     Instruction, RunResult, RuntimeError, SCHED_ACTOR, SCHED_STREAM, Simulation, TaskBuilder,
 };

--- a/crates/ledger-sim/src/origin.rs
+++ b/crates/ledger-sim/src/origin.rs
@@ -1,0 +1,95 @@
+//! Effect origin capture: where in system-under-test source a journaled
+//! effect happened.
+//!
+//! Origins live in a per-session side channel keyed by entry hash. They never
+//! enter journal bytes, hashes, or roots: two runs with capture enabled and
+//! disabled must produce byte-identical journals. Wasm guests and programmatic
+//! runs report [`OriginSource::Unknown`]; native callers get source locations
+//! through the tracked aliases on [`crate::effects::{NetExt, FsExt}`].
+
+use core::panic::Location;
+
+use ledger_format::Hash;
+
+/// Source location of the system-under-test call that produced an effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectOrigin {
+    pub file: &'static str,
+    pub line: u32,
+    pub column: u32,
+}
+
+impl EffectOrigin {
+    /// Capture the current call site. Only meaningful on functions marked
+    /// `#[track_caller]`.
+    #[track_caller]
+    pub fn caller() -> Self {
+        Self::from(Location::caller())
+    }
+}
+
+impl From<&'static Location<'static>> for EffectOrigin {
+    fn from(location: &'static Location<'static>) -> Self {
+        Self {
+            file: location.file(),
+            line: location.line(),
+            column: location.column(),
+        }
+    }
+}
+
+/// Provenance of one journaled effect.
+///
+/// The Span variant is where OpenTelemetry ingest lands later (span name plus
+/// trace id instead of a Rust call site); it is declared now so adding it to
+/// the wire-adjacent surface later stays additive.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum OriginSource {
+    /// Native caller captured through `#[track_caller]`.
+    Source(EffectOrigin),
+    /// Foreign-process or guest effect with span-level provenance.
+    Span { name: Box<str>, trace_id: [u8; 16] },
+    /// No provenance available (guests, programmatic runs).
+    #[default]
+    Unknown,
+}
+
+impl From<&'static Location<'static>> for OriginSource {
+    fn from(location: &'static Location<'static>) -> Self {
+        Self::Source(EffectOrigin::from(location))
+    }
+}
+
+/// Side-channel log of effect origins, keyed by journal entry hash.
+///
+/// Never serialized into journals or manifests; lives only as long as the
+/// backend session. Deterministic by construction: the same seed produces the
+/// same entries, so replay repopulates the same origins.
+#[derive(Default)]
+pub(crate) struct OriginLog {
+    map: std::collections::HashMap<Hash, OriginSource>,
+    order: Vec<Hash>,
+}
+
+impl OriginLog {
+    pub fn record(&mut self, id: Hash, source: OriginSource) {
+        if matches!(source, OriginSource::Unknown) {
+            return;
+        }
+        if self.map.insert(id, source).is_none() {
+            self.order.push(id);
+        }
+    }
+
+    pub fn get(&self, id: &Hash) -> Option<&OriginSource> {
+        self.map.get(id)
+    }
+
+    /// Snapshot in append order.
+    pub fn snapshot(&self) -> Vec<(Hash, OriginSource)> {
+        self.order
+            .iter()
+            .map(|id| (*id, self.map[id].clone()))
+            .collect()
+    }
+}

--- a/crates/ledger-sim/tests/effect_origins.rs
+++ b/crates/ledger-sim/tests/effect_origins.rs
@@ -1,0 +1,136 @@
+//! Effect-origin capture: side-channel population, format neutrality, and
+//! default delegation for backends without origin support.
+
+use ledger_sim::{Effects, FsExt, Net, NetExt, OriginSource, SeedTree, SimBackend};
+
+fn fresh_backend() -> SimBackend {
+    SimBackend::for_actor(SeedTree::new([7; 32]), 1)
+}
+
+fn message(to: usize) -> ledger_sim::Message {
+    ledger_sim::Message {
+        from: 1,
+        to,
+        payload: 42,
+        send_id: [0; 32],
+        deliver_at: 0,
+    }
+}
+
+#[test]
+fn tracked_calls_record_origins_keyed_by_entry_hash() {
+    let backend = fresh_backend();
+    let send_line = line!() + 1;
+    let delivered = backend.net().send_tracked(message(2));
+    assert!(delivered);
+    let write_id = backend
+        .fs()
+        .write_tracked("k", 7)
+        .expect("tracked write journals");
+
+    let origins = backend.origins_snapshot();
+    assert_eq!(origins.len(), 2, "send and write must both record");
+
+    for (id, source) in &origins {
+        assert!(backend.journal_snapshot().get(id).is_some());
+        match source {
+            OriginSource::Source(origin) => {
+                assert!(
+                    origin.file.ends_with("effect_origins.rs"),
+                    "origin must point at the SUT call site, got {}",
+                    origin.file
+                );
+            }
+            other => panic!("native calls must capture Source origins, got {other:?}"),
+        }
+    }
+
+    let (_, send_origin) = &origins[0];
+    let OriginSource::Source(origin) = send_origin else {
+        panic!("send origin must be a Source");
+    };
+    assert_eq!(
+        origin.line, send_line,
+        "origin line is the tracked call site"
+    );
+
+    let write_origin = backend.origin_of(&write_id).expect("write origin recorded");
+    assert!(matches!(write_origin, OriginSource::Source(_)));
+}
+
+#[test]
+fn recv_inherits_the_origin_of_its_send() {
+    let backend = fresh_backend();
+    backend.net().send_tracked(message(2));
+
+    // Deliver the sent message to its target task and receive it through
+    // the boundary.
+    {
+        let now = backend.clock().now();
+        let _ = backend.net().recv(2, now);
+    }
+
+    let origins = backend.origins_snapshot();
+    assert_eq!(origins.len(), 2, "recv must inherit, not add a new origin");
+}
+
+#[test]
+fn capture_never_changes_journal_bytes() {
+    // Identical effect sequences through tracked and untracked paths must
+    // produce identical journal roots: origins live outside the journal.
+    let run = |tracked: bool| {
+        let backend = fresh_backend();
+        if tracked {
+            backend.net().send_tracked(message(2));
+            let _ = backend.fs().write_tracked("k", 7);
+            let _ = backend.fs().fsync_tracked();
+        } else {
+            let _ = backend.net().send(message(2));
+            let _ = backend.fs().write("k", 7);
+            let _ = backend.fs().fsync();
+        }
+        (
+            backend.journal_snapshot().root_hash(),
+            backend.origins_snapshot().len(),
+        )
+    };
+
+    let (plain_root, plain_origins) = run(false);
+    let (tracked_root, tracked_origins) = run(true);
+    assert_eq!(plain_root, tracked_root, "origins must not perturb the DAG");
+    assert_eq!(plain_origins, 0);
+    assert_eq!(tracked_origins, 3);
+}
+
+#[test]
+fn loc_variants_delegate_to_base_behavior_by_default() {
+    // A minimal Net impl without origin support keeps working through the
+    // tracked alias and the explicit variant alike.
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingNet {
+        sends: AtomicUsize,
+    }
+
+    impl Net for CountingNet {
+        fn send(&self, _message: ledger_sim::Message) -> bool {
+            self.sends.fetch_add(1, Ordering::Relaxed);
+            true
+        }
+
+        fn recv(&self, _task: usize, _now: u64) -> Option<ledger_sim::Message> {
+            None
+        }
+
+        fn has_ready_message(&self, _task: usize, _now: u64) -> bool {
+            false
+        }
+    }
+
+    let net = CountingNet {
+        sends: AtomicUsize::new(0),
+    };
+    assert!(net.send_loc(message(3), OriginSource::Unknown));
+    assert!(net.send_tracked(message(3)));
+    assert_eq!(net.sends.load(Ordering::Relaxed), 2);
+}


### PR DESCRIPTION
Journaled effects can now record the system-under-test call site that produced them. A per-session side channel maps entry hashes to origins; journal bytes, hashes, and roots are untouched, and a property test asserts byte-identical roots with capture on and off.

- `send_loc` / `write_loc` / `fsync_loc` / `crash_loc` variants with delegating defaults, so backends without origin support keep working
- `NetExt::send_tracked` / `FsExt::write_tracked` capture the call site via `#[track_caller]`
- `recv` inherits the origin of its send, keeping lineage continuous across the network boundary
- `SimBackend::origins_snapshot()` and `origin_of()` for inspection