### PR TITLE
feat(explorer,cli,ldgr-rt): surface effect origins through the finding pipeline

### DIFF
--- a/crates/ldgr-rt/src/runtime.rs
+++ b/crates/ldgr-rt/src/runtime.rs
@@ -443,6 +443,7 @@ impl Handle {
     /// rebuilding the handle from scratch. Returns `false` when the link is
     /// partitioned or `to` exceeds the actor id range, mirroring an
     /// undeliverable link rather than truncating the id.
+    #[track_caller]
     pub fn net_send(&self, to: usize, payload: u64) -> bool {
         let Ok(to_id) = u32::try_from(to) else {
             return false;
@@ -450,7 +451,7 @@ impl Handle {
         #[cfg(feature = "sim-link")]
         {
             if let Some(b) = &self.boundary {
-                return b.send(to_id as usize, payload);
+                return b.send_tracked(to_id as usize, payload);
             }
         }
         Conn::new(self.actor, to_id, self.shared_net.clone()).send(payload)

--- a/crates/ledger-cli/src/main.rs
+++ b/crates/ledger-cli/src/main.rs
@@ -128,6 +128,28 @@ fn json_violation(reason: &str, steps: usize, root: Hash) -> String {
     .to_string()
 }
 
+/// Print captured origins for the witness entries of a violation.
+///
+/// Origins exist only for runs that flowed through origin-capturing calls
+/// (tracked facade sends, direct backend use). Instruction-program runs have
+/// no per-effect call sites, so this prints nothing there by design.
+fn print_effect_origins(origins: &[(Hash, ledger_sim::OriginSource)], witnesses: &[Hash]) {
+    let hits: Vec<_> = origins
+        .iter()
+        .filter(|(id, _)| witnesses.contains(id))
+        .collect();
+    if hits.is_empty() {
+        return;
+    }
+    println!("Effect origins:");
+    for (id, source) in hits {
+        if let ledger_sim::OriginSource::Source(origin) = source {
+            let hex = ledger_format::hash_to_hex(id);
+            println!("  {} at {}:{}", &hex[..8], origin.file, origin.line);
+        }
+    }
+}
+
 fn run_sim(
     cli: &Cli,
     verbose: bool,
@@ -185,6 +207,7 @@ fn run_sim(
                 ledger_format::hash_to_hex(&finding.run.journal.root_hash())
             );
             println!("Steps executed: {}", finding.run.steps);
+            print_effect_origins(&finding.run.origins, &finding.verdict.witnesses);
         }
     } else if cli.json {
         println!(r#"{{"status":"passed","runs":{runs}}}"#);

--- a/crates/ledger-explorer/src/certs.rs
+++ b/crates/ledger-explorer/src/certs.rs
@@ -656,6 +656,7 @@ mod tests {
             steps: 0,
             monitor_issues: Vec::new(),
             applied_faults: Vec::new(),
+            origins: Vec::new(),
         };
         CampaignReport {
             runs_executed: 10,
@@ -960,6 +961,7 @@ mod tests {
             steps: 0,
             monitor_issues: Vec::new(),
             applied_faults: Vec::new(),
+            origins: Vec::new(),
         };
         let report = CampaignReport {
             runs_executed: 1,
@@ -1150,6 +1152,7 @@ mod tests {
                     steps: 0,
                     monitor_issues: Vec::new(),
                     applied_faults: Vec::new(),
+                    origins: Vec::new(),
                 },
                 verdict: Verdict::fail(vec![[7u8; 32]], "test"),
             }],
@@ -1289,6 +1292,7 @@ mod tests {
             steps: 0,
             monitor_issues: Vec::new(),
             applied_faults: Vec::new(),
+            origins: Vec::new(),
         };
         let report = CampaignReport {
             runs_executed: 1,

--- a/crates/ledger-explorer/src/coverage.rs
+++ b/crates/ledger-explorer/src/coverage.rs
@@ -455,6 +455,7 @@ mod tests {
             steps: 0,
             monitor_issues: Vec::new(),
             applied_faults: Vec::new(),
+            origins: Vec::new(),
         };
         let root_hex = crate::certs::hash_to_hex(&run.journal.root_hash());
         let report = CampaignReport {

--- a/crates/ledger-explorer/src/diagnosis.rs
+++ b/crates/ledger-explorer/src/diagnosis.rs
@@ -67,6 +67,7 @@ mod tests {
             steps: 0,
             monitor_issues: Vec::new(),
             applied_faults: Vec::new(),
+            origins: Vec::new(),
         }
     }
 

--- a/crates/ledger-explorer/src/forensics.rs
+++ b/crates/ledger-explorer/src/forensics.rs
@@ -118,6 +118,7 @@ mod tests {
             steps: 0,
             monitor_issues: Vec::new(),
             applied_faults: Vec::new(),
+            origins: Vec::new(),
         }
     }
 

--- a/crates/ledger-explorer/src/minimizer/pipeline.rs
+++ b/crates/ledger-explorer/src/minimizer/pipeline.rs
@@ -45,6 +45,7 @@ fn run_for_check(journal: Journal) -> RunResult {
         steps: 0,
         monitor_issues: Vec::new(),
         applied_faults: Vec::new(),
+        origins: Vec::new(),
     }
 }
 

--- a/crates/ledger-explorer/src/minimizer/tests.rs
+++ b/crates/ledger-explorer/src/minimizer/tests.rs
@@ -154,6 +154,7 @@ fn run_for_test(journal: Journal) -> RunResult {
         steps: 0,
         monitor_issues: Vec::new(),
         applied_faults: Vec::new(),
+        origins: Vec::new(),
     }
 }
 

--- a/crates/ledger-explorer/src/monitor.rs
+++ b/crates/ledger-explorer/src/monitor.rs
@@ -297,6 +297,7 @@ mod tests {
             steps: 0,
             monitor_issues: Vec::new(),
             applied_faults: Vec::new(),
+            origins: Vec::new(),
         }
     }
 

--- a/crates/ledger-explorer/src/oracle.rs
+++ b/crates/ledger-explorer/src/oracle.rs
@@ -970,6 +970,7 @@ mod tests {
             steps: 0,
             monitor_issues: Vec::new(),
             applied_faults: Vec::new(),
+            origins: Vec::new(),
         }
     }
 

--- a/crates/ledger-explorer/src/search/tests.rs
+++ b/crates/ledger-explorer/src/search/tests.rs
@@ -657,6 +657,7 @@ fn campaign_report_renders_ndjson_coverage_records() {
         steps: 0,
         monitor_issues: Vec::new(),
         applied_faults: Vec::new(),
+        origins: Vec::new(),
     };
     let report = CampaignReport {
         runs_executed: 9,

--- a/crates/ledger-explorer/tests/minimize_gate.rs
+++ b/crates/ledger-explorer/tests/minimize_gate.rs
@@ -94,6 +94,7 @@ fn run_for_check(journal: ledger_journal::Journal) -> RunResult {
         steps: 0,
         monitor_issues: Vec::new(),
         applied_faults: Vec::new(),
+        origins: Vec::new(),
     }
 }
 

--- a/crates/ledger-explorer/tests/minimize_pipeline.rs
+++ b/crates/ledger-explorer/tests/minimize_pipeline.rs
@@ -51,6 +51,7 @@ fn full_pipeline_minimizes_stale_read_and_preserves_violation() {
         steps: 0,
         monitor_issues: Vec::new(),
         applied_faults: Vec::new(),
+        origins: Vec::new(),
     };
     assert!(
         oracle.check(&run).violated,

--- a/crates/ledger-sim/src/executor/effects.rs
+++ b/crates/ledger-sim/src/executor/effects.rs
@@ -5,6 +5,7 @@
 //! executor state. The `Effects`/`Net`/`Fs` trait implementations and the
 //! sleeping/receiving futures live here; the orchestration loop, the task
 //! table, and the shared state stay in the module root.
+use crate::origin::OriginSource;
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
@@ -281,16 +282,25 @@ impl Boundary {
 
     /// Send a message immediately, journaling a `Send` entry.
     pub fn send(&self, to: usize, payload: u64) -> bool {
-        Net::send(
-            self,
-            Message {
-                from: self.task,
-                to,
-                payload,
-                send_id: [0; 32],
-                deliver_at: self.shared.time.borrow().now(),
-            },
-        )
+        self.send_inner(to, payload, None)
+    }
+
+    /// Send with origin capture: the caller's source location lands in the
+    /// session side channel keyed by the Send entry hash.
+    #[track_caller]
+    pub fn send_tracked(&self, to: usize, payload: u64) -> bool {
+        self.send_inner(to, payload, Some(core::panic::Location::caller().into()))
+    }
+
+    /// Snapshot the captured effect origins in append order.
+    pub fn origins_snapshot(&self) -> Vec<(ledger_format::Hash, OriginSource)> {
+        self.shared.origins.borrow().snapshot()
+    }
+
+    fn send_inner(&self, to: usize, payload: u64, at: Option<OriginSource>) -> bool {
+        // Behavior-identical to the historical Net::send path; the origin is
+        // recorded inside send_core against the journaled Send entry.
+        self.send_core(to, payload, 0, at)
     }
 
     /// Toggle a directed partition at the current point of the run.
@@ -329,7 +339,7 @@ impl Boundary {
     /// delay is added to the current virtual time, so identical seeds yield
     /// identical delivery order.
     pub fn send_timed(&self, to: usize, payload: u64, delay: u64) -> bool {
-        self.send_core(to, payload, delay)
+        self.send_core(to, payload, delay, None)
     }
 
     /// Single send path for `send` and `send_timed`.
@@ -337,7 +347,13 @@ impl Boundary {
     /// Journals `Send`, applies the fault and swarm policies, then delivers
     /// through the configured link or the direct queue. Delay 0 keeps
     /// unfaulted journals byte-identical.
-    fn send_core(&self, to: usize, payload: u64, base_delay: u64) -> bool {
+    fn send_core(
+        &self,
+        to: usize,
+        payload: u64,
+        base_delay: u64,
+        at: Option<OriginSource>,
+    ) -> bool {
         let now = self.shared.time.borrow().now();
         let id = match self.append(
             EntryKind::Send,
@@ -353,6 +369,9 @@ impl Boundary {
                 return false;
             }
         };
+        if let Some(origin) = at {
+            self.shared.origins.borrow_mut().record(id, origin);
+        }
         if self.shared.dropped_events.contains(&id) {
             if let Err(error) = self.append(
                 EntryKind::Fault {
@@ -780,7 +799,7 @@ impl Effects for Boundary {
 
 impl Net for Boundary {
     fn send(&self, message: Message) -> bool {
-        self.send_core(message.to, message.payload, 0)
+        self.send_core(message.to, message.payload, 0, None)
     }
 
     fn recv(&self, task: usize, now: u64) -> Option<Message> {

--- a/crates/ledger-sim/src/executor/mod.rs
+++ b/crates/ledger-sim/src/executor/mod.rs
@@ -105,6 +105,8 @@ pub(crate) struct ExecutorShared {
     fault_classes_used: RefCell<HashSet<u64>>,
     /// Event ids whose scheduled fault injections took effect.
     applied_faults: RefCell<Vec<Hash>>,
+    /// Effect origins side channel keyed by entry hash (crate::origin).
+    origins: RefCell<crate::origin::OriginLog>,
     /// Fault schedule applied at exact causal positions.
     fault_schedule: Vec<SimFault>,
     /// Configured journaling-FS crash model, or `None` for the black-box
@@ -204,6 +206,7 @@ impl Executor {
             coverage: RefCell::new(HashMap::new()),
             fault_classes_used: RefCell::new(HashSet::new()),
             applied_faults: RefCell::new(Vec::new()),
+            origins: RefCell::new(crate::origin::OriginLog::default()),
             fault_schedule: config.fault_schedule().to_vec(),
             #[cfg(feature = "sim-fs-journaling")]
             fs_journaling: config.fs_journaling(),
@@ -312,6 +315,7 @@ impl Executor {
             steps: self.steps,
             monitor_issues,
             applied_faults: self.shared.applied_faults.borrow().clone(),
+            origins: self.shared.origins.borrow().snapshot(),
             journal_error: self.shared.journal_error.borrow().clone(),
         })
     }
@@ -479,6 +483,49 @@ mod tests {
         future: impl Future<Output = ()> + 'static,
     ) -> Pin<Box<dyn Future<Output = ()> + 'static>> {
         Box::pin(future)
+    }
+
+    #[test]
+    fn send_tracked_records_origin_in_the_shared_log() {
+        let executor = executor_with(
+            9,
+            256,
+            [|b| {
+                boxed(async move {
+                    b.send_tracked(1, 42);
+                })
+            }],
+        );
+        let run = executor.run().expect("run succeeds");
+        assert_eq!(run.origins.len(), 1, "tracked send must record one origin");
+        match &run.origins[0].1 {
+            crate::origin::OriginSource::Source(origin) => {
+                assert!(
+                    origin.file.ends_with("mod.rs"),
+                    "origin must point at the test call site, got {}",
+                    origin.file
+                );
+            }
+            other => panic!("expected a Source origin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn untracked_send_leaves_origins_empty() {
+        let executor = executor_with(
+            9,
+            256,
+            [|b| {
+                boxed(async move {
+                    b.send(1, 42);
+                })
+            }],
+        );
+        let run = executor.run().expect("run succeeds");
+        assert!(
+            run.origins.is_empty(),
+            "plain sends must not record origins"
+        );
     }
 
     /// A root task body: a function building a boxed future from a boundary.

--- a/crates/ledger-sim/src/runtime.rs
+++ b/crates/ledger-sim/src/runtime.rs
@@ -104,6 +104,9 @@ pub struct RunResult {
     pub monitor_issues: Vec<MonitorIssue>,
     /// Event ids whose scheduled fault injections took effect.
     pub applied_faults: Vec<ledger_format::Hash>,
+    /// Effect origins keyed by entry hash, in append order. Empty unless the
+    /// run flowed through origin-capturing calls (crate::origin).
+    pub origins: Vec<(ledger_format::Hash, crate::origin::OriginSource)>,
     /// First journal-append failure observed on a path that cannot propagate.
     ///
     /// Append failures on non-`Result` surfaces (send helpers, spawn, crash)


### PR DESCRIPTION
Stacked on #36.

Effect origins now flow end to end: the executor boundary records the caller location for tracked sends, `RunResult` carries the snapshot, and the CLI prints the call sites behind a violation's witness entries.

- `Boundary::send_tracked` with `#[track_caller]`; the origin lands in the shared log keyed by the Send entry hash
- `RunResult.origins` populated at run outcome; empty for instruction-program runs, which have no per-effect call sites, so the display degrades to silence rather than noise
- `ledger sim` violation output prints `Effect origins:` with `hash at file:line` for witnessed entries
- `ldgr-rt::Handle::net_send` is now `#[track_caller]` and routes through the tracked path, so facade users capture real SUT call sites for free

530 tests pass across the four touched crates; clippy clean with `-D warnings`.