### PR TITLE
feat(sim,cli): origin parity across executor paths

### DIFF
--- a/crates/ledger-cli/src/ldfi_cmd.rs
+++ b/crates/ledger-cli/src/ldfi_cmd.rs
@@ -58,6 +58,10 @@ pub struct LdfiReport {
     pub applied: usize,
     /// Number of injections that were voided.
     pub voided: usize,
+    /// Journal entry hashes witnessing the violation.
+    pub witnesses: Vec<Hash>,
+    /// Effect origins for the witness entries, when captured.
+    pub origins: Vec<(Hash, ledger_sim::OriginSource)>,
     /// True when the journal prefix before the first fault matches the base run.
     pub prefix_ok: bool,
 }
@@ -123,6 +127,8 @@ pub fn run_ldfi(
         reason: finding.verdict.reason.clone(),
         steps: finding.run.steps,
         journal_root: finding.run.journal.root_hash(),
+        witnesses: finding.verdict.witnesses.clone(),
+        origins: finding.run.origins.clone(),
         hypotheses: hypotheses
             .into_iter()
             .map(|hypothesis| LdfiHypothesis {

--- a/crates/ledger-cli/src/main.rs
+++ b/crates/ledger-cli/src/main.rs
@@ -525,6 +525,7 @@ fn run_ldfi(
             ledger_format::hash_to_hex(&report.journal_root)
         );
         println!("Steps executed: {}", report.steps);
+        print_effect_origins(&report.origins, &report.witnesses);
         println!("LDFI hypotheses:");
         for (index, hypothesis) in report.hypotheses.iter().enumerate() {
             println!(
@@ -560,7 +561,15 @@ fn ldfi_json(report: &LdfiReport) -> String {
             "explanation": hypothesis.explanation
         })).collect::<Vec<_>>(),
         "replay": {"applied": report.applied, "voided": report.voided, "prefix_ok": report.prefix_ok},
-        "schedule": report.schedule.iter().map(describe_injection).collect::<Vec<_>>()
+        "schedule": report.schedule.iter().map(describe_injection).collect::<Vec<_>>(),
+        "origins": report.origins.iter().map(|(id, source)| match source {
+            ledger_sim::OriginSource::Source(origin) => serde_json::json!({
+                "entry": ledger_format::hash_to_hex(id),
+                "file": origin.file,
+                "line": origin.line
+            }),
+            _ => serde_json::json!({"entry": ledger_format::hash_to_hex(id)}),
+        }).collect::<Vec<_>>()
     }).to_string()
 }
 

--- a/crates/ledger-sim/src/executor/effects.rs
+++ b/crates/ledger-sim/src/executor/effects.rs
@@ -297,6 +297,18 @@ impl Boundary {
         self.shared.origins.borrow().snapshot()
     }
 
+    /// Give a Recv entry the origin of the Send that produced it, keeping
+    /// lineage continuous across the network boundary.
+    fn inherit_recv_origin(&self, recv_id: Option<Hash>, send_id: Hash) {
+        if let Some(id) = recv_id {
+            // Clone out before re-locking; the mutex is not reentrant.
+            let inherited = self.shared.origins.borrow().get(&send_id).cloned();
+            if let Some(origin) = inherited {
+                self.shared.origins.borrow_mut().record(id, origin);
+            }
+        }
+    }
+
     fn send_inner(&self, to: usize, payload: u64, at: Option<OriginSource>) -> bool {
         // Behavior-identical to the historical Net::send path; the origin is
         // recorded inside send_core against the journaled Send entry.
@@ -611,16 +623,20 @@ impl Boundary {
     pub(crate) fn recv_now(&self) -> Option<u64> {
         let now = self.shared.time.borrow().now();
         let message = self.shared.net.borrow_mut().recv_at(self.task, now)?;
-        if let Err(error) = self.append(
+        let recv_id = match self.append(
             EntryKind::Recv,
             [message.send_id],
             Payload::Number(message.payload),
         ) {
-            // The message is already consumed; surface the failed append
-            // instead of losing it on the return-None path.
-            self.shared.record_journal_error(error);
-            return None;
-        }
+            Ok(id) => Some(id),
+            Err(error) => {
+                // The message is already consumed; surface the failed append
+                // instead of losing it on the return-None path.
+                self.shared.record_journal_error(error);
+                None
+            }
+        };
+        self.inherit_recv_origin(recv_id, message.send_id);
         Some(message.payload)
     }
 
@@ -804,13 +820,18 @@ impl Net for Boundary {
 
     fn recv(&self, task: usize, now: u64) -> Option<Message> {
         let message = self.shared.net.borrow_mut().recv_at(task, now)?;
-        if let Err(error) = self.append(
+        let recv_id = match self.append(
             EntryKind::Recv,
             [message.send_id],
             Payload::Number(message.payload),
         ) {
-            self.shared.record_journal_error(error);
-        }
+            Ok(id) => Some(id),
+            Err(error) => {
+                self.shared.record_journal_error(error);
+                None
+            }
+        };
+        self.inherit_recv_origin(recv_id, message.send_id);
         Some(message)
     }
 
@@ -820,6 +841,17 @@ impl Net for Boundary {
 }
 
 impl Fs for Boundary {
+    fn write_loc(
+        &self,
+        path: &str,
+        value: u64,
+        at: OriginSource,
+    ) -> Result<Hash, ledger_journal::JournalError> {
+        let id = Fs::write(self, path, value)?;
+        self.shared.origins.borrow_mut().record(id, at);
+        Ok(id)
+    }
+
     fn write(&self, path: &str, value: u64) -> Result<Hash, ledger_journal::JournalError> {
         let mut journal = self.shared.journal.borrow_mut();
         let mut fs = self.shared.fs.borrow_mut();
@@ -835,6 +867,12 @@ impl Fs for Boundary {
         );
         self.inject_write_fault(id, path)?;
         self.maybe_crash_on_write(path, value)?;
+        Ok(id)
+    }
+
+    fn fsync_loc(&self, at: OriginSource) -> Result<Hash, ledger_journal::JournalError> {
+        let id = Fs::fsync(self)?;
+        self.shared.origins.borrow_mut().record(id, at);
         Ok(id)
     }
 
@@ -873,16 +911,35 @@ impl Fs for Boundary {
     }
 
     fn crash(&self) {
-        if let Err(error) = self.append(
+        self.crash_impl();
+    }
+
+    fn crash_loc(&self, at: OriginSource) {
+        if let Some(id) = self.crash_impl() {
+            self.shared.origins.borrow_mut().record(id, at);
+        }
+    }
+}
+
+impl Boundary {
+    /// Journal the crash-fault entry and fold storage into the post-crash
+    /// state. Returns the entry id when journaling worked.
+    fn crash_impl(&self) -> Option<Hash> {
+        let id = match self.append(
             EntryKind::Fault {
                 fault: FaultSpec::CrashState(0),
             },
             [],
             Payload::Empty,
         ) {
-            self.shared.record_journal_error(error);
-        }
+            Ok(id) => Some(id),
+            Err(error) => {
+                self.shared.record_journal_error(error);
+                None
+            }
+        };
         self.fs_crash();
+        id
     }
 }
 
@@ -932,6 +989,10 @@ impl Future for RecvFuture {
                         self.task,
                         Some(id),
                     );
+                    let inherited = self.shared.origins.borrow().get(&message.send_id).cloned();
+                    if let Some(origin) = inherited {
+                        self.shared.origins.borrow_mut().record(id, origin);
+                    }
                 }
                 Err(error) => self.shared.record_journal_error(error),
             }

--- a/crates/ledger-sim/src/executor/mod.rs
+++ b/crates/ledger-sim/src/executor/mod.rs
@@ -511,6 +511,48 @@ mod tests {
     }
 
     #[test]
+    fn recv_inherits_the_origin_of_its_send() {
+        let executor = executor_with(
+            9,
+            256,
+            [
+                |b| {
+                    boxed(async move {
+                        b.send_tracked(1, 42);
+                    })
+                },
+                |b| {
+                    boxed(async move {
+                        let _ = b.recv().await;
+                    })
+                },
+            ],
+        );
+        let run = executor.run().expect("run succeeds");
+        assert_eq!(run.origins.len(), 2, "recv must inherit the send origin");
+        assert_eq!(
+            run.origins[0].1, run.origins[1].1,
+            "inherited origin must match the send"
+        );
+    }
+
+    #[test]
+    fn tracked_storage_write_records_origin() {
+        use crate::effects::FsExt;
+        let executor = executor_with(
+            9,
+            256,
+            [|b| {
+                boxed(async move {
+                    let _ = b.fs().write_tracked("k", 7);
+                })
+            }],
+        );
+        let run = executor.run().expect("run succeeds");
+        assert_eq!(run.origins.len(), 1, "tracked write must record one origin");
+    }
+
+    #[test]
     fn untracked_send_leaves_origins_empty() {
         let executor = executor_with(
             9,


### PR DESCRIPTION
Stacked on #37. Closes the three parity gaps so effect origins behave identically on every path.

- Executor recv entries now inherit the origin of their send (Boundary Net recv, recv_now, and the receive future), matching SimBackend
- Boundary storage effects gain origin capture: write_loc, fsync_loc, crash_loc
- LdfiReport carries witnesses and origins; the ldfi output prints the same Effect origins block as sim, and the JSON gains an origins array

532 tests pass; clippy clean with -D warnings.