### PR TITLE
feat(sim,explorer): liveness outcomes for incomplete runs

### DIFF
--- a/crates/ldgr-rt/src/lib.rs
+++ b/crates/ldgr-rt/src/lib.rs
@@ -33,7 +33,7 @@ pub use ledger_format::StreamId;
 pub use net::{Conn, SharedNetwork, shared_network};
 pub use rng::DetRng;
 pub use runtime::{
-    Handle, IpcFault, JournalFault, RunConfig, RunResult, RuntimeError, TaskMain,
+    Handle, IpcFault, JournalFault, RunCompletion, RunConfig, RunResult, RuntimeError, TaskMain,
     register_workload, run, run_named,
 };
 pub use task::{TaskId, task_id_for};

--- a/crates/ldgr-rt/src/runtime.rs
+++ b/crates/ldgr-rt/src/runtime.rs
@@ -168,7 +168,7 @@ pub enum RunCompletion {
     Blocked,
 }
 
-#[cfg(feature = "sim")]
+#[cfg(feature = "sim-link")]
 impl From<ledger_sim::RunOutcome> for RunCompletion {
     fn from(outcome: ledger_sim::RunOutcome) -> Self {
         match outcome {

--- a/crates/ldgr-rt/src/runtime.rs
+++ b/crates/ldgr-rt/src/runtime.rs
@@ -154,6 +154,31 @@ impl From<RunConfigBuilder> for RunConfig {
 // Result / error
 // ---------------------------------------------------------------------------
 
+/// Whether a run reached completion, and why it stopped when it did not.
+///
+/// Facade-local carrier: liveness detail requires the simulation backend;
+/// other builds report [`RunCompletion::Completed`] for their runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunCompletion {
+    /// Every task finished.
+    Completed,
+    /// The step budget ran out while tasks were still ready or blocked.
+    BudgetExhausted,
+    /// No task was ready and at least one task was still pending.
+    Blocked,
+}
+
+#[cfg(feature = "sim")]
+impl From<ledger_sim::RunOutcome> for RunCompletion {
+    fn from(outcome: ledger_sim::RunOutcome) -> Self {
+        match outcome {
+            ledger_sim::RunOutcome::Completed => Self::Completed,
+            ledger_sim::RunOutcome::BudgetExhausted => Self::BudgetExhausted,
+            ledger_sim::RunOutcome::Blocked => Self::Blocked,
+        }
+    }
+}
+
 /// Outcome of a completed run.
 #[derive(Debug, Clone)]
 pub struct RunResult {
@@ -162,6 +187,8 @@ pub struct RunResult {
     pub journal_root: Option<[u8; 32]>,
     /// Number of executor steps consumed.
     pub steps: usize,
+    /// Whether the run completed, and the liveness reason when it did not.
+    pub outcome: RunCompletion,
 }
 
 /// Journal invariant failure raised by a simulation backend.
@@ -724,6 +751,7 @@ fn run_with_sim(config: RunConfig, main: Main) -> Result<RunResult, RuntimeError
     Ok(RunResult {
         journal_root: Some(res.journal.root_hash()),
         steps: res.steps,
+        outcome: res.outcome.into(),
     })
 }
 
@@ -738,6 +766,7 @@ async fn run_via_ipc(config: RunConfig, main: Main) -> Result<RunResult, Runtime
     let outcome = engine.run_workload_with_steps(workload, config.seed(), config.max_steps(), 1)?;
     let root = outcome.journal_root().ok_or(RuntimeError::MissingRoot)?;
     Ok(RunResult {
+        outcome: RunCompletion::Completed,
         journal_root: Some(root),
         steps: outcome.steps,
     })
@@ -763,6 +792,7 @@ fn run_with_tokio(config: RunConfig, main: Main) -> Result<RunResult, RuntimeErr
     });
     clear_current();
     Ok(RunResult {
+        outcome: RunCompletion::Completed,
         journal_root: None,
         steps: 0,
     })

--- a/crates/ldgr-rt/tests/public_contract.rs
+++ b/crates/ldgr-rt/tests/public_contract.rs
@@ -32,6 +32,7 @@ fn name_runtime_error(error: &RuntimeError) -> &'static str {
 /// `journal_root` and `steps` are public fields under every feature set.
 fn construct_run_result() -> RunResult {
     RunResult {
+        outcome: ldgr_rt::RunCompletion::Completed,
         journal_root: None,
         steps: 0,
     }

--- a/crates/ledger-explorer/src/certs.rs
+++ b/crates/ledger-explorer/src/certs.rs
@@ -648,6 +648,7 @@ mod tests {
         )
         .unwrap();
         let run = RunResult {
+            outcome: ledger_sim::RunOutcome::Completed,
             journal_error: None,
             journal: j,
             decisions: Vec::new(),
@@ -953,6 +954,7 @@ mod tests {
         lower_bound: u64,
     ) -> CampaignCertificate {
         let run = RunResult {
+            outcome: ledger_sim::RunOutcome::Completed,
             journal_error: None,
             journal: journal.clone(),
             decisions: Vec::new(),
@@ -1144,6 +1146,7 @@ mod tests {
             findings: vec![Finding {
                 seed: [7u8; 32],
                 run: RunResult {
+                    outcome: ledger_sim::RunOutcome::Completed,
                     journal_error: None,
                     journal: journal.clone(),
                     decisions: Vec::new(),
@@ -1284,6 +1287,7 @@ mod tests {
             .append(EntryKind::Send, 1, [], Payload::Pair { left: 2, right: 7 })
             .unwrap();
         let run = RunResult {
+            outcome: ledger_sim::RunOutcome::Completed,
             journal_error: None,
             journal: journal.clone(),
             decisions: Vec::new(),

--- a/crates/ledger-explorer/src/coverage.rs
+++ b/crates/ledger-explorer/src/coverage.rs
@@ -447,6 +447,7 @@ mod tests {
             )
             .unwrap();
         let run = RunResult {
+            outcome: ledger_sim::RunOutcome::Completed,
             journal_error: None,
             journal,
             decisions: Vec::new(),

--- a/crates/ledger-explorer/src/diagnosis.rs
+++ b/crates/ledger-explorer/src/diagnosis.rs
@@ -59,6 +59,7 @@ mod tests {
 
     fn run(journal: Journal) -> RunResult {
         RunResult {
+            outcome: ledger_sim::RunOutcome::Completed,
             journal_error: None,
             journal,
             decisions: Vec::new(),

--- a/crates/ledger-explorer/src/forensics.rs
+++ b/crates/ledger-explorer/src/forensics.rs
@@ -110,6 +110,7 @@ mod tests {
 
     fn run(journal: Journal) -> RunResult {
         RunResult {
+            outcome: ledger_sim::RunOutcome::Completed,
             journal_error: None,
             journal,
             decisions: Vec::new(),

--- a/crates/ledger-explorer/src/minimizer/pipeline.rs
+++ b/crates/ledger-explorer/src/minimizer/pipeline.rs
@@ -37,6 +37,7 @@ pub struct MinimizedRepro {
 /// fields are neutral.
 fn run_for_check(journal: Journal) -> RunResult {
     RunResult {
+        outcome: ledger_sim::RunOutcome::Completed,
         journal_error: None,
         journal,
         decisions: Vec::new(),

--- a/crates/ledger-explorer/src/minimizer/tests.rs
+++ b/crates/ledger-explorer/src/minimizer/tests.rs
@@ -146,6 +146,7 @@ fn chain_journal(values: &[u64]) -> Journal {
 
 fn run_for_test(journal: Journal) -> RunResult {
     RunResult {
+        outcome: ledger_sim::RunOutcome::Completed,
         journal_error: None,
         journal,
         decisions: Vec::new(),

--- a/crates/ledger-explorer/src/monitor.rs
+++ b/crates/ledger-explorer/src/monitor.rs
@@ -289,6 +289,7 @@ mod tests {
 
     fn empty_run_with_journal(journal: Journal) -> RunResult {
         RunResult {
+            outcome: ledger_sim::RunOutcome::Completed,
             journal_error: None,
             journal,
             decisions: Vec::new(),

--- a/crates/ledger-explorer/src/oracle.rs
+++ b/crates/ledger-explorer/src/oracle.rs
@@ -962,6 +962,7 @@ mod tests {
 
     fn run_for_value_oracle(journal: Journal) -> RunResult {
         RunResult {
+            outcome: ledger_sim::RunOutcome::Completed,
             journal_error: None,
             journal,
             decisions: Vec::new(),

--- a/crates/ledger-explorer/src/search/bandit.rs
+++ b/crates/ledger-explorer/src/search/bandit.rs
@@ -271,7 +271,7 @@ pub fn run_bandit_campaign<W: Workload, O: Oracle>(
                 distinct,
             },
         );
-        let verdict = oracle.check(&run);
+        let verdict = super::effective_verdict(&run, oracle.check(&run));
         let found = verdict.violated;
         if found {
             findings.push(Finding {

--- a/crates/ledger-explorer/src/search/campaign.rs
+++ b/crates/ledger-explorer/src/search/campaign.rs
@@ -107,7 +107,7 @@ pub fn run_campaign<W: Workload, O: Oracle>(
             .map_err(|error| format!("simulation failed: {error:?}"))?;
 
         distinct_roots.insert(run.journal.root_hash());
-        let verdict = oracle.check(&run);
+        let verdict = super::effective_verdict(&run, oracle.check(&run));
         if verdict.violated {
             findings.push(Finding {
                 seed: config.seed(),
@@ -181,7 +181,7 @@ pub fn run_monitored_campaign<W: Workload, O: Oracle>(
             .map_err(|error| format!("simulation failed: {error:?}"))?;
 
         distinct_roots.insert(run.journal.root_hash());
-        let primary = oracle.check(&run);
+        let primary = super::effective_verdict(&run, oracle.check(&run));
         let monitored = monitor_oracle.check(&run);
         let verdict = merge_monitor_verdict(primary, monitored);
         if verdict.violated {
@@ -210,4 +210,54 @@ pub fn search<W: Workload, O: Oracle>(
     attempts: usize,
 ) -> Result<Option<Finding>, String> {
     super::find_first_violation(workload, oracle, &base, attempts).map(|(finding, _)| finding)
+}
+
+#[cfg(test)]
+mod liveness_tests {
+    use super::*;
+    use crate::oracle::Verdict;
+    use ledger_sim::{Instruction, RunConfig};
+
+    /// A workload whose single task blocks on a receive that never has a
+    /// sender: the run quiesces with a pending task.
+    struct DeadlockWorkload;
+
+    impl Workload for DeadlockWorkload {
+        fn programs(&self) -> Vec<Vec<Instruction>> {
+            vec![vec![Instruction::Receive]]
+        }
+
+        fn history(&self, _run: &RunResult) -> Vec<crate::oracle::HistoryOperation> {
+            Vec::new()
+        }
+    }
+
+    struct PassOracle;
+
+    impl Oracle for PassOracle {
+        fn check(&self, _run: &ledger_sim::RunResult) -> Verdict {
+            Verdict::pass()
+        }
+    }
+
+    #[test]
+    fn quiesced_pending_tasks_become_liveness_findings() {
+        let config = RunConfig::builder().seed([9; 32]).max_steps(64).build();
+        let report =
+            run_campaign(&DeadlockWorkload, &PassOracle, config, 2).expect("campaign succeeds");
+        assert_eq!(
+            report.findings.len(),
+            2,
+            "every attempt must surface as a liveness finding"
+        );
+        assert!(
+            report.findings[0].verdict.reason.contains("liveness"),
+            "reason must name liveness: {}",
+            report.findings[0].verdict.reason
+        );
+        assert!(
+            !report.findings[0].verdict.witnesses.is_empty(),
+            "liveness findings carry journal witnesses"
+        );
+    }
 }

--- a/crates/ledger-explorer/src/search/feedback.rs
+++ b/crates/ledger-explorer/src/search/feedback.rs
@@ -137,7 +137,7 @@ pub fn run_feedback_campaign_with_state<W: Workload, O: Oracle>(
         distinct_roots.insert(run.journal.root_hash());
         variants.push(format!("attempt={attempt} policy=feedback-search"));
         search_runs += 1;
-        let verdict = oracle.check(&run);
+        let verdict = super::effective_verdict(&run, oracle.check(&run));
         if verdict.violated {
             let finding = Finding {
                 seed: config.seed(),

--- a/crates/ledger-explorer/src/search/input_axis.rs
+++ b/crates/ledger-explorer/src/search/input_axis.rs
@@ -81,7 +81,7 @@ where
         let run = Simulation::new(base.clone(), workload.programs())
             .run()
             .map_err(|error| format!("simulation failed: {error:?}"))?;
-        let verdict = oracle.check(&run);
+        let verdict = super::effective_verdict(&run, oracle.check(&run));
         if verdict.violated {
             return Ok(Some(Finding {
                 seed: attempt_seed,

--- a/crates/ledger-explorer/src/search/joint.rs
+++ b/crates/ledger-explorer/src/search/joint.rs
@@ -221,7 +221,7 @@ pub fn run_joint_campaign_with_state<W: Workload, O: Oracle>(
                 distinct,
             },
         );
-        let verdict = oracle.check(&run);
+        let verdict = super::effective_verdict(&run, oracle.check(&run));
         if verdict.violated {
             findings.push(Finding {
                 seed: attempt_seed,

--- a/crates/ledger-explorer/src/search/mod.rs
+++ b/crates/ledger-explorer/src/search/mod.rs
@@ -53,7 +53,7 @@ fn find_first_violation<W: Workload, O: Oracle>(
         let run = Simulation::new(config.clone(), workload.programs())
             .run()
             .map_err(|error| format!("simulation failed: {error:?}"))?;
-        let verdict = oracle.check(&run);
+        let verdict = effective_verdict(&run, oracle.check(&run));
         if verdict.violated {
             return Ok((
                 Some(Finding {
@@ -66,6 +66,34 @@ fn find_first_violation<W: Workload, O: Oracle>(
         }
     }
     Ok((None, budget))
+}
+
+/// Promote an incomplete run to a liveness violation.
+///
+/// A run that never completed is a finding regardless of what the oracle
+/// saw on the partial journal: an exhausted step budget or pending tasks
+/// at quiescence both mean the system under test failed to make progress.
+pub fn effective_verdict(run: &ledger_sim::RunResult, verdict: crate::Verdict) -> crate::Verdict {
+    if run.outcome == ledger_sim::RunOutcome::Completed {
+        return verdict;
+    }
+    let reason = match run.outcome {
+        ledger_sim::RunOutcome::BudgetExhausted => format!(
+            "liveness violation: step budget exhausted after {} steps with tasks pending",
+            run.steps
+        ),
+        _ => "liveness violation: run quiesced with pending tasks".to_string(),
+    };
+    // Structural witnesses first; a stalled run may have none, so fall
+    // back to the journal tail: the last entries show where progress
+    // stopped.
+    let mut witnesses = crate::oracle::witnesses_from_journal(&run.journal);
+    if witnesses.is_empty() {
+        let ids: Vec<ledger_format::Hash> = run.journal.entries().map(|entry| entry.id).collect();
+        let start = ids.len().saturating_sub(8);
+        witnesses = ids[start..].to_vec();
+    }
+    crate::oracle::Verdict::fail(witnesses, reason)
 }
 
 /// Shared fault-class budget for the swarm axis across every campaign type.

--- a/crates/ledger-explorer/src/search/tests.rs
+++ b/crates/ledger-explorer/src/search/tests.rs
@@ -649,6 +649,7 @@ fn campaign_report_renders_ndjson_coverage_records() {
         .expect("append must succeed");
     let root_hex = hash_to_hex(&journal.root_hash());
     let run = RunResult {
+        outcome: ledger_sim::RunOutcome::Completed,
         journal_error: None,
         journal,
         decisions: Vec::new(),

--- a/crates/ledger-explorer/tests/minimize_gate.rs
+++ b/crates/ledger-explorer/tests/minimize_gate.rs
@@ -86,6 +86,7 @@ fn failing_programs() -> Vec<Vec<Instruction>> {
 /// same shape the minimizer pipeline uses internally.
 fn run_for_check(journal: ledger_journal::Journal) -> RunResult {
     RunResult {
+        outcome: ledger_sim::RunOutcome::Completed,
         journal_error: None,
         journal,
         decisions: Vec::new(),

--- a/crates/ledger-explorer/tests/minimize_pipeline.rs
+++ b/crates/ledger-explorer/tests/minimize_pipeline.rs
@@ -43,6 +43,7 @@ fn full_pipeline_minimizes_stale_read_and_preserves_violation() {
     );
 
     let run = RunResult {
+        outcome: ledger_sim::RunOutcome::Completed,
         journal_error: None,
         journal: repro.journal.clone(),
         decisions: Vec::new(),

--- a/crates/ledger-sim/src/executor/mod.rs
+++ b/crates/ledger-sim/src/executor/mod.rs
@@ -230,12 +230,16 @@ impl Executor {
     /// Run until all tasks finish or the step budget is reached.
     pub fn run(mut self) -> Result<RunResult, RuntimeError> {
         self.journal_spawns()?;
+        // The while-condition exit means the budget ran out; the breaks in
+        // the loop record the earlier liveness outcomes.
+        let mut outcome = crate::RunOutcome::BudgetExhausted;
         while self.steps < self.config.max_steps() {
             self.wake_blocked_with_messages()?;
             if self.shared.ready.borrow().is_empty() {
                 self.advance_quiescent()?;
                 if self.shared.ready.borrow().is_empty() {
                     if self.all_tasks_done() {
+                        outcome = crate::RunOutcome::Completed;
                         break;
                     }
                     if let Some(earliest) = self.shared.net.borrow().earliest_delivery_time()
@@ -245,6 +249,7 @@ impl Executor {
                         self.wake_blocked_with_messages()?;
                     }
                     if self.shared.ready.borrow().is_empty() {
+                        outcome = crate::RunOutcome::Blocked;
                         break;
                     }
                 }
@@ -275,10 +280,10 @@ impl Executor {
         if let Some(error) = self.shared.journal_error.borrow().clone() {
             return Err(RuntimeError::Journal(error));
         }
-        if self.steps == self.config.max_steps() {
-            return Err(RuntimeError::StepLimit {
-                limit: self.config.max_steps(),
-            });
+        // The last step can complete every task exactly as the budget runs
+        // out; completion wins over the budget default in that case.
+        if outcome == crate::RunOutcome::BudgetExhausted && self.all_tasks_done() {
+            outcome = crate::RunOutcome::Completed;
         }
         let journal = self.shared.journal.borrow().clone();
         let mut monitor_issues = if self.config.monitor() {
@@ -313,6 +318,7 @@ impl Executor {
             trace,
             registers,
             steps: self.steps,
+            outcome,
             monitor_issues,
             applied_faults: self.shared.applied_faults.borrow().clone(),
             origins: self.shared.origins.borrow().snapshot(),
@@ -981,8 +987,38 @@ mod tests {
                 })
             }],
         );
-        let error = executor.run().unwrap_err();
-        assert!(matches!(error, RuntimeError::StepLimit { .. }));
+        let run = executor
+            .run()
+            .expect("budget exhaustion is an outcome, not an error");
+        assert_eq!(run.outcome, crate::RunOutcome::BudgetExhausted);
+        assert!(
+            run.steps > 0,
+            "a budget-exhausted run must have executed steps"
+        );
+    }
+
+    #[test]
+    fn quiesced_pending_tasks_report_blocked_outcome() {
+        let executor = executor_with(
+            9,
+            64,
+            [|b| {
+                boxed(async move {
+                    let _ = b.recv().await;
+                })
+            }],
+        );
+        let run = executor
+            .run()
+            .expect("quiescence with pending tasks is an outcome, not an error");
+        assert_eq!(run.outcome, crate::RunOutcome::Blocked);
+    }
+
+    #[test]
+    fn finished_run_reports_completed_outcome() {
+        let executor = executor_with(9, 64, [|_b| boxed(async {})]);
+        let run = executor.run().expect("empty task completes");
+        assert_eq!(run.outcome, crate::RunOutcome::Completed);
     }
 }
 

--- a/crates/ledger-sim/src/lib.rs
+++ b/crates/ledger-sim/src/lib.rs
@@ -43,7 +43,8 @@ pub use executor::{Boundary, Executor};
 pub use net::{DnsTable, LinkConfig, Message, SimNet, backoff, backoff_jittered};
 pub use origin::{EffectOrigin, OriginSource};
 pub use runtime::{
-    Instruction, RunResult, RuntimeError, SCHED_ACTOR, SCHED_STREAM, Simulation, TaskBuilder,
+    Instruction, RunOutcome, RunResult, RuntimeError, SCHED_ACTOR, SCHED_STREAM, Simulation,
+    TaskBuilder,
 };
 pub use scheduler::{NoveltyModel, Scheduler, StepTrace};
 pub use seedtree::SeedTree;

--- a/crates/ledger-sim/src/runtime.rs
+++ b/crates/ledger-sim/src/runtime.rs
@@ -79,6 +79,17 @@ pub enum Instruction {
     Done,
 }
 
+/// Whether a run reached completion, and why it stopped when it did not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunOutcome {
+    /// Every task finished.
+    Completed,
+    /// The step budget ran out while tasks were still ready or blocked.
+    BudgetExhausted,
+    /// No task was ready and at least one task was still pending.
+    Blocked,
+}
+
 /// Result of a completed deterministic run.
 #[derive(Debug, Clone)]
 pub struct RunResult {
@@ -97,6 +108,8 @@ pub struct RunResult {
     pub registers: Vec<u64>,
     /// Number of executed instructions.
     pub steps: usize,
+    /// Whether the run completed, and the liveness reason when it did not.
+    pub outcome: RunOutcome,
     /// Defects found by the journal-correctness monitor.
     ///
     /// The run does not fail on monitor issues by default; callers decide how
@@ -124,6 +137,11 @@ pub enum RuntimeError {
     /// Journal invariant failed.
     Journal(JournalError),
     /// The instruction budget was exhausted.
+    ///
+    /// No longer produced: budget exhaustion is now reported through
+    /// [`RunResult::outcome`] so the partial journal stays inspectable.
+    /// The variant remains because the runtime facade maps it in its
+    /// public contract.
     StepLimit { limit: usize },
 }
 


### PR DESCRIPTION
Wave 1, item 2 of the ratified hardening roadmap. Stacked on #40.

Budget exhaustion used to be a bare `RuntimeError::StepLimit`: the partial journal was dropped, campaigns skipped the run, and a livelocked or deadlocked system under test produced no finding at all.

Runs that never complete are now first-class observations:

- `RunResult` gains `outcome: RunOutcome` (`Completed` / `BudgetExhausted` / `Blocked`); the executor returns the partial journal in every case, so oracles can still inspect what ran
- `RuntimeError::StepLimit` is no longer produced; the variant stays because the runtime facade maps it in its public contract
- The facade gains a local `RunCompletion` mirror (the root name `RunOutcome` is owned by the IPC wire type); non-sim builds report `Completed`
- Search and campaign sites promote incomplete runs to liveness findings via `effective_verdict`, with journal-tail witnesses when no structural entries exist - so LDFI can minimize a deadlock like any other violation
- `sim --ndjson` reports `liveness-violation` status

537 tests pass; clippy clean with -D warnings.