### PR TITLE
feat(lint): hash-collection warn-lint for the simulation path

### DIFF
--- a/crates/ldgr-rt/src/net.rs
+++ b/crates/ldgr-rt/src/net.rs
@@ -27,6 +27,8 @@ pub struct Conn {
 pub(crate) struct SharedNet {
     // Queue preserves insertion order to keep FIFO per actor pair.
     queue: VecDeque<Message>,
+    // ledger-lint:allow:HashSet (partition pairs are membership-checked;
+    // the set is never iterated)
     partitions: std::collections::HashSet<(ActorId, ActorId)>,
 }
 

--- a/crates/ledger-lint/src/lib.rs
+++ b/crates/ledger-lint/src/lib.rs
@@ -6,4 +6,5 @@
 pub mod scanner;
 pub use scanner::{
     ALLOW_MARKER, FORBIDDEN_PATTERNS, LintViolation, ScanResult, scan_rs_files, scan_source,
+    scan_warnings,
 };

--- a/crates/ledger-lint/src/main.rs
+++ b/crates/ledger-lint/src/main.rs
@@ -8,13 +8,19 @@ use std::process;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: ledger-lint <path-to-source-file-or-dir>...");
+    let deny_warnings = args.iter().any(|arg| arg == "--deny-warnings");
+    let targets: Vec<&String> = args
+        .iter()
+        .skip(1)
+        .filter(|arg| *arg != "--deny-warnings")
+        .collect();
+    if targets.is_empty() {
+        eprintln!("Usage: ledger-lint [--deny-warnings] <path-to-source-file-or-dir>...");
         process::exit(1);
     }
 
     let mut aggregate = ScanResult::default();
-    for target in &args[1..] {
+    for target in targets {
         let path = Path::new(target);
         if !path.exists() {
             aggregate
@@ -26,6 +32,7 @@ fn main() {
         aggregate.files_scanned += result.files_scanned;
         aggregate.errors.extend(result.errors);
         aggregate.violating_files.extend(result.violating_files);
+        aggregate.warning_files.extend(result.warning_files);
     }
 
     for (file, violations) in &aggregate.violating_files {
@@ -33,16 +40,22 @@ fn main() {
     }
 
     let total = aggregate.total_violations();
+    let total_warnings = aggregate.total_warnings();
     println!(
-        "ledger-lint: scanned {} source file(s); {} violation(s) in {} file(s).",
+        "ledger-lint: scanned {} source file(s); {} violation(s) in {} file(s); {} warn-level finding(s) in {} file(s).",
         aggregate.files_scanned,
         total,
-        aggregate.violating_files.len()
+        aggregate.violating_files.len(),
+        total_warnings,
+        aggregate.warning_files.len()
     );
+    for (file, warnings) in &aggregate.warning_files {
+        print_warn_report(file, warnings);
+    }
     for err in &aggregate.errors {
         eprintln!("ledger-lint: {err}");
     }
-    if total > 0 || !aggregate.errors.is_empty() {
+    if total > 0 || !aggregate.errors.is_empty() || (deny_warnings && total_warnings > 0) {
         process::exit(1);
     }
 }
@@ -59,5 +72,17 @@ fn print_report(file: &Path, violations: &[LintViolation]) {
             violation.line_number, violation.line_content
         );
         println!("    Advice: {}", violation.advice);
+    }
+}
+
+fn print_warn_report(file: &Path, warnings: &[LintViolation]) {
+    println!(
+        "{}: {} warn-level determinism finding(s):",
+        file.display(),
+        warnings.len()
+    );
+    for warning in warnings {
+        println!("  Line {}: `{}`", warning.line_number, warning.line_content);
+        println!("    Advice: {}", warning.advice);
     }
 }

--- a/crates/ledger-lint/src/scanner.rs
+++ b/crates/ledger-lint/src/scanner.rs
@@ -112,6 +112,33 @@ const BARE_PREFIX_PATTERNS: &[(&str, &str)] = &[
     ("env::args", "ambient process args; pass inputs via Effects"),
 ];
 
+/// Files under these path prefixes are simulation-path code: hash-collection
+/// iteration order can reach replay behavior or journal-adjacent output.
+const WARN_SCOPE_PREFIXES: &[&str] = &[
+    "crates/ledger-sim/src/",
+    "crates/wasm-guest/src/",
+    "crates/ldgr-rt/src/",
+    "guests/",
+];
+
+/// Warn-level patterns for the simulation path.
+///
+/// Hash collections are deterministic within one build, but their iteration
+/// order is not stable across builds, so any iteration that can reach
+/// journal order, decision order, or reported output is a replay risk.
+/// Lookup-only use is fine; mark it with `// ledger-lint:allow:HashMap`
+/// (or `HashSet`) plus a reason.
+const WARN_PATTERNS: &[(&str, &str)] = &[
+    (
+        "HashMap",
+        "hash-map iteration order is unstable across builds; sort before iterating, derive order from the journal, or use BTreeMap; allow-marker lookup-only use",
+    ),
+    (
+        "HashSet",
+        "hash-set iteration order is unstable across builds; sort before iterating or use BTreeSet; allow-marker membership-only use",
+    ),
+];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LintViolation {
     pub pattern: String,
@@ -170,6 +197,8 @@ fn collect_pattern_exemptions(source: &str) -> Vec<String> {
 pub struct ScanResult {
     /// Files that produced at least one violation, paired with their violations.
     pub violating_files: Vec<(PathBuf, Vec<LintViolation>)>,
+    /// Files that produced at least one warn-level finding, paired with them.
+    pub warning_files: Vec<(PathBuf, Vec<LintViolation>)>,
     /// Number of source files scanned, excluding allow-marked files.
     pub files_scanned: usize,
     /// Non-fatal errors encountered while walking directories or reading files.
@@ -181,6 +210,14 @@ impl ScanResult {
         self.violating_files
             .iter()
             .map(|(_path, violations)| violations.len())
+            .sum()
+    }
+
+    /// Total warn-level findings across all scanned files.
+    pub fn total_warnings(&self) -> usize {
+        self.warning_files
+            .iter()
+            .map(|(_path, warnings)| warnings.len())
             .sum()
     }
 
@@ -200,6 +237,10 @@ impl ScanResult {
         let violations = scan_source(&content);
         if !violations.is_empty() {
             self.violating_files.push((path.to_path_buf(), violations));
+        }
+        let warnings = scan_warnings(path, &content);
+        if !warnings.is_empty() {
+            self.warning_files.push((path.to_path_buf(), warnings));
         }
     }
 }
@@ -304,6 +345,53 @@ pub fn scan_source(source: &str) -> Vec<LintViolation> {
         }
     }
     violations
+}
+
+/// Return true when `path` is inside the warn scope for hash collections.
+fn is_warn_scoped(path: &Path) -> bool {
+    let text = path.to_string_lossy().replace('\\', "/");
+    WARN_SCOPE_PREFIXES
+        .iter()
+        .any(|prefix| text.starts_with(prefix))
+}
+
+/// Scan one source file for warn-level determinism risks.
+///
+/// Honors the same file-scoped allow directives as the forbidden-pattern
+/// scan: a full-file marker skips the file, and `ledger-lint:allow:HashMap`
+/// exempts that pattern for the whole file. Import lines never warn.
+pub fn scan_warnings(path: &Path, source: &str) -> Vec<LintViolation> {
+    if !is_warn_scoped(path) || has_full_allow_marker(source) {
+        return Vec::new();
+    }
+    let exemptions = collect_pattern_exemptions(source);
+    let exempted: Vec<bool> = WARN_PATTERNS
+        .iter()
+        .map(|(pattern, _)| exemptions.iter().any(|sub| pattern.contains(sub)))
+        .collect();
+    let mut warnings = Vec::new();
+    let mut in_block_comment = false;
+    for (line_idx, line) in source.lines().enumerate() {
+        let code = strip_comments(line, &mut in_block_comment);
+        let trimmed = code.trim();
+        if trimmed.is_empty() || is_import_line(trimmed) {
+            continue;
+        }
+        for (idx, &(pattern, advice)) in WARN_PATTERNS.iter().enumerate() {
+            if exempted[idx] {
+                continue;
+            }
+            if code.contains(pattern) {
+                warnings.push(LintViolation {
+                    pattern: pattern.to_string(),
+                    line_number: line_idx + 1,
+                    line_content: trimmed.to_string(),
+                    advice: advice.to_string(),
+                });
+            }
+        }
+    }
+    warnings
 }
 
 /// Remove line and block comments from one source line.
@@ -416,6 +504,34 @@ mod tests {
         let v = scan_source(code);
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].pattern, "env::var");
+    }
+
+    #[test]
+    fn hashmap_warn_fires_only_inside_simulation_scope() {
+        let code = "fn f() { let m: HashMap<u8, u8> = HashMap::new(); }";
+        let in_scope = Path::new("crates/ledger-sim/src/x.rs");
+        let out_of_scope = Path::new("crates/ledger-cli/src/x.rs");
+        let warnings = scan_warnings(in_scope, code);
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].pattern, "HashMap");
+        assert!(scan_warnings(out_of_scope, code).is_empty());
+    }
+
+    #[test]
+    fn imports_and_allow_markers_skip_hash_warnings() {
+        let code = "use std::collections::HashMap;\n\
+                    // ledger-lint:allow:HashMap (lookup-only fd map)\n\
+                    fn f(m: HashMap<u8, u8>) {}";
+        let in_scope = Path::new("crates/ledger-sim/src/x.rs");
+        assert!(scan_warnings(in_scope, code).is_empty());
+    }
+
+    #[test]
+    fn full_file_allow_suppresses_hash_warnings() {
+        let code = "// ledger-lint:allow (host passthrough)\n\
+                    fn f(s: HashSet<u8>) {}";
+        let in_scope = Path::new("crates/ledger-sim/src/x.rs");
+        assert!(scan_warnings(in_scope, code).is_empty());
     }
 
     #[test]

--- a/crates/ledger-sim/src/backend_wasm.rs
+++ b/crates/ledger-sim/src/backend_wasm.rs
@@ -346,6 +346,7 @@ pub struct WasmBackend {
     engine: Engine,
     store: Store<WasmStoreData>,
     instance: Option<Instance>,
+    // ledger-lint:allow:HashMap (name-keyed instance lookups; never iterated)
     instances: HashMap<String, Instance>,
     fuel_budget: u64,
 }

--- a/crates/ledger-sim/src/dpor.rs
+++ b/crates/ledger-sim/src/dpor.rs
@@ -97,6 +97,9 @@ pub fn run_dpor(
     };
 
     let journal_entries = base.journal.entries().collect::<Vec<_>>();
+    // ledger-lint:allow:HashMap ledger-lint:allow:HashSet (explored-set
+    // membership and per-actor clock lookups keyed by ActorId; no iteration
+    // reaches decisions)
     let mut explored = HashSet::new();
     // `last_vc` holds each task's vector clock as of the current branch point:
     // entries journaled before the step under inspection, advanced per step

--- a/crates/ledger-sim/src/executor/effects.rs
+++ b/crates/ledger-sim/src/executor/effects.rs
@@ -182,6 +182,8 @@ impl Boundary {
         let operator = match choice % 4 {
             0 => crate::simfs::CrashOperator::DropAllUnsynced,
             1 => {
+                // ledger-lint:allow:HashSet (single-element set; the crash
+                // operator sorts before iterating)
                 let mut dropped = HashSet::new();
                 dropped.insert(path.to_owned());
                 crate::simfs::CrashOperator::DropSubset(dropped)

--- a/crates/ledger-sim/src/executor/mod.rs
+++ b/crates/ledger-sim/src/executor/mod.rs
@@ -100,6 +100,9 @@ pub(crate) struct ExecutorShared {
     ///
     /// Every journal write funnels through [`Self::journal_append`], so the
     /// journal can never gain an entry the boundary did not report.
+    // ledger-lint:allow:HashMap ledger-lint:allow:HashSet (coverage is keyed
+    // lookup and collected in sorted order at the run tail; fault classes are
+    // membership and len only)
     coverage: RefCell<HashMap<ActorId, u64>>,
     /// Distinct crash-state classes applied this run (campaign budget).
     fault_classes_used: RefCell<HashSet<u64>>,
@@ -293,10 +296,13 @@ impl Executor {
         };
         if self.config.monitor() {
             let coverage = self.shared.coverage.borrow();
-            let boundary_entries = coverage
+            let mut boundary_entries = coverage
                 .iter()
                 .map(|(actor, count)| (*actor, *count))
                 .collect::<Vec<_>>();
+            // Deterministic monitor input order: the map itself is
+            // lookup-only, but this vector feeds issue enumeration.
+            boundary_entries.sort_unstable();
             drop(coverage);
             monitor_issues.extend(JournalCorrectnessMonitor::check_coverage(
                 &journal,

--- a/crates/ledger-sim/src/net.rs
+++ b/crates/ledger-sim/src/net.rs
@@ -135,6 +135,8 @@ pub fn backoff_jittered(
 #[derive(Debug, Default)]
 pub struct SimNet {
     queue: VecDeque<Message>,
+    // ledger-lint:allow:HashSet (partition pairs are membership-checked;
+    // the set is never iterated)
     partitions: HashSet<(usize, usize)>,
     /// Optional reorder window: when nonzero, up to this many messages sharing
     /// a delivery tick are served newest-first instead of FIFO (UDP-style

--- a/crates/ledger-sim/src/origin.rs
+++ b/crates/ledger-sim/src/origin.rs
@@ -67,6 +67,8 @@ impl From<&'static Location<'static>> for OriginSource {
 /// same entries, so replay repopulates the same origins.
 #[derive(Default)]
 pub(crate) struct OriginLog {
+    // ledger-lint:allow:HashMap (keyed by entry hash; append order comes
+    // from the side Vec, never from map iteration)
     map: std::collections::HashMap<Hash, OriginSource>,
     order: Vec<Hash>,
 }

--- a/crates/ledger-sim/src/scheduler.rs
+++ b/crates/ledger-sim/src/scheduler.rs
@@ -32,6 +32,8 @@ pub struct StepTrace {
 /// list is reordered by `swap_remove`, so a position is not a stable identity.
 #[derive(Debug, Clone, Default)]
 pub struct NoveltyModel {
+    // ledger-lint:allow:HashMap ledger-lint:allow:HashSet (membership and keyed
+    // lookup only; iteration never escapes the scheduler)
     seen_transitions: HashSet<(EntryKind, EntryKind)>,
     seen_actor_pairs: HashSet<(ActorId, ActorId)>,
     seen_vc_branches: HashSet<u64>,

--- a/crates/ledger-sim/src/sentinel.rs
+++ b/crates/ledger-sim/src/sentinel.rs
@@ -164,6 +164,8 @@ impl TscTrapGuard {
 /// Runtime sentinel that tracks and flags unjournaled ambient effects.
 #[derive(Debug, Default)]
 pub struct Sentinel {
+    // ledger-lint:allow:HashSet (leak classes are membership-checked and
+    // counted; the set is never iterated for output order)
     detected_leaks: HashSet<LeakClass>,
 }
 

--- a/crates/ledger-sim/src/sentinel_belt.rs
+++ b/crates/ledger-sim/src/sentinel_belt.rs
@@ -279,6 +279,7 @@ fn belt_armed() -> bool {
 /// and the kernel would kill the process.
 fn pre_warm_ambient_entropy() {
     // Deliberate discard: the map exists only to seed the hasher here.
+    // ledger-lint:allow:HashMap (compile probe; never populated)
     let _ = std::collections::HashMap::<u64, u64>::new();
 }
 

--- a/crates/ledger-sim/src/simfs.rs
+++ b/crates/ledger-sim/src/simfs.rs
@@ -10,6 +10,8 @@ pub enum CrashOperator {
     /// Drop all dirty, unsynced writes.
     DropAllUnsynced,
     /// Drop an adversarial subset of dirty paths.
+    // ledger-lint:allow:HashSet (apply_crash_operator sorts the subset
+    // before iterating, so restore order is deterministic)
     DropSubset(HashSet<String>),
     /// Simulate a torn write by persisting a truncated/partial value.
     TornWrite { path: String, partial_value: u64 },
@@ -302,7 +304,12 @@ impl SimFs {
                     .collect();
             }
             CrashOperator::DropSubset(paths_to_drop) => {
-                for path in paths_to_drop {
+                // HashSet order must not choose the restore sequence; sort
+                // so the crash operator stays deterministic even if the
+                // loop ever grows journaled steps.
+                let mut ordered: Vec<&String> = paths_to_drop.iter().collect();
+                ordered.sort();
+                for path in ordered {
                     if let Some((synced_val, synced_hash)) = self.synced.get(path) {
                         self.values
                             .insert(path.clone(), (*synced_val, *synced_hash, PageState::Clean));

--- a/crates/ledger-sim/src/wasi_fs.rs
+++ b/crates/ledger-sim/src/wasi_fs.rs
@@ -149,6 +149,7 @@ pub fn bytes_to_u64(bytes: &[u8]) -> u64 {
 /// In-memory fd table mapping virtual fds to `SimFs` path keys.
 #[derive(Debug, Default)]
 pub struct WasiFdTable {
+    // ledger-lint:allow:HashMap (fd-to-path lookups only; never iterated)
     map: HashMap<u32, String>,
 }
 


### PR DESCRIPTION
Wave 1, item 3 of the ratified hardening roadmap. Stacked on #41.

Hash-collection iteration order is stable within a build but not across builds, so any iteration that can reach journal order, decisions, or reported output is a replay risk. A textual scanner cannot tell lookups from iterations, so this ships warn-first instead of deny:

- New warn rules for HashMap/HashSet scoped to the simulation path (ledger-sim, wasm-guest, ldgr-rt, guests); import lines never warn
- Same allow directives as the forbidden patterns: file-scoped `ledger-lint:allow:HashMap` / `HashSet` with a reason
- Findings print as warnings and never fail the gate; `--deny-warnings` escalates to exit 1 when the triage is ready

Triage of every current hit (all marked with reasons): membership or keyed lookup only - scheduler tables, DPOR explored set, vector clocks, partition sets, fd table, wasm instances, sentinel leak classes, origin log. Two genuine hardenings came out of the review: the SimFs crash operator now sorts its DropSubset before iterating, and the executor collects per-actor coverage in sorted order for the monitor.

The workspace gate stays green: 0 violations, 0 warnings.