### PR TITLE
feat(services): explorer application services over the typed surfaces

### DIFF
--- a/crates/ledger-cli/src/cert_cmd.rs
+++ b/crates/ledger-cli/src/cert_cmd.rs
@@ -4,9 +4,12 @@
 use std::io::Read;
 use std::path::Path;
 
-use ledger_explorer::certs::{CERT_MAX_BYTES, check_cert_bytes};
+use ledger_explorer::certs::{CERT_MAX_BYTES, CertError, check_cert_bytes};
 use ledger_explorer::search::PersistentJournal;
-use ledger_explorer::{CampaignCertificate, CertError};
+use ledger_explorer::services::ServiceError;
+use ledger_explorer::services::{
+    parse_statement, validate_cut_against_journal, validate_statement,
+};
 
 /// Errors from `ledger cert verify`.
 #[derive(Debug, thiserror::Error)]
@@ -26,6 +29,21 @@ pub enum CertVerifyError {
     /// JSON serialization failed.
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+}
+
+/// Maps a statement service failure onto the command error, keeping the
+/// decode-versus-validation distinction the CLI surfaces.
+fn to_verify_error(error: ServiceError) -> CertVerifyError {
+    match error {
+        ServiceError::Cert(err) => match &err {
+            CertError::Verification(_) => CertVerifyError::Verification(err),
+            _ => CertVerifyError::Decode(err),
+        },
+        ServiceError::Journal(err) => CertVerifyError::JournalOpen(err),
+        other => CertVerifyError::Decode(CertError::Schema(format!(
+            "unexpected service failure: {other}"
+        ))),
+    }
 }
 
 /// Verifies a campaign certificate JSON file.
@@ -48,15 +66,14 @@ pub fn run_verify(
         .read_to_string(&mut raw)
         .map_err(CertVerifyError::Io)?;
     check_cert_bytes(raw.len()).map_err(CertVerifyError::Decode)?;
-    let cert = CampaignCertificate::from_json(&raw).map_err(CertVerifyError::Decode)?;
+    let cert = parse_statement(&raw).map_err(to_verify_error)?;
     let mode_label = if let Some(journal_dir) = journal {
         let persistent =
             PersistentJournal::open(journal_dir).map_err(CertVerifyError::JournalOpen)?;
-        cert.verify_with_journal(persistent.journal())
-            .map_err(CertVerifyError::Verification)?;
+        validate_cut_against_journal(&cert, persistent.journal()).map_err(to_verify_error)?;
         "journal-bound"
     } else {
-        cert.verify().map_err(CertVerifyError::Verification)?;
+        validate_statement(&cert).map_err(to_verify_error)?;
         "statement-validated"
     };
 

--- a/crates/ledger-cli/src/ldfi_cmd.rs
+++ b/crates/ledger-cli/src/ldfi_cmd.rs
@@ -4,11 +4,13 @@
 //! LDFI fault hypotheses, and replays the top hypothesis with fault
 //! injection to report how many faults applied or were voided.
 
-use ledger_explorer::ldfi::hypothesis_to_schedule;
-use ledger_explorer::maxsat::encode_hazard;
+use ledger_explorer::FaultHypothesis;
 use ledger_explorer::oracle::{HistoryOracle, KeyValueSpec};
-use ledger_explorer::search::{FaultReplayError, SearchError, replay_with_faults, search};
-use ledger_explorer::{FaultHypothesis, SolverConfig, SolverError, select_solver, solve_with};
+use ledger_explorer::services::ServiceError;
+use ledger_explorer::services::{
+    ldfi_solve, replay_faults, schedule_from_hypothesis, search_first,
+};
+use ledger_explorer::solver::SolverConfig;
 use ledger_format::Hash;
 use ledger_sim::{Policy, RunConfig, SimFault};
 use thiserror::Error;
@@ -18,15 +20,9 @@ use crate::{DefaultMiniKv, MaxSatEngineArg, default_pct_mix, seed_from_u64};
 /// Errors from the `ldfi` campaign driver.
 #[derive(Debug, Error)]
 pub enum LdfiCmdError {
-    /// Campaign search failed.
+    /// A service operation failed; the source error is preserved.
     #[error(transparent)]
-    Search(#[from] SearchError),
-    /// Ranking the fault hypotheses failed.
-    #[error(transparent)]
-    Solve(#[from] SolverError),
-    /// Fault replay failed.
-    #[error(transparent)]
-    Replay(#[from] FaultReplayError),
+    Service(#[from] ServiceError),
 }
 
 #[derive(Debug, Clone)]
@@ -91,7 +87,7 @@ pub fn run_ldfi(
         .max_steps(max_steps)
         .build();
 
-    let Some(finding) = search(&workload, &oracle, config, attempts)? else {
+    let Some(finding) = search_first(&workload, &oracle, config, attempts)? else {
         return Ok(None);
     };
 
@@ -101,17 +97,13 @@ pub fn run_ldfi(
         engine: maxsat_engine.to_solver_engine(),
         ..SolverConfig::default()
     };
-    let encoded = encode_hazard(&finding.run.journal, &finding.verdict, &solver_config)
-        .map_err(LdfiCmdError::Solve)?;
-    let mut solver = select_solver(&solver_config, &encoded);
     let hypotheses: Vec<FaultHypothesis> =
-        solve_with(solver.as_mut(), &finding.run.journal, &finding.verdict)
-            .map_err(LdfiCmdError::Solve)?;
+        ldfi_solve(&finding.run.journal, &finding.verdict, &solver_config)?;
     let schedule = hypotheses
         .first()
-        .map(|top| hypothesis_to_schedule(top, &finding.run.journal))
+        .map(|top| schedule_from_hypothesis(top, &finding.run.journal))
         .unwrap_or_default();
-    let replay_report = replay_with_faults(
+    let replay_report = replay_faults(
         &workload,
         &finding.run.journal,
         finding.seed,

--- a/crates/ledger-cli/src/main.rs
+++ b/crates/ledger-cli/src/main.rs
@@ -19,8 +19,10 @@ use ledger_cli::scaffold_consensus;
 use ledger_cli::{
     Cli, Command, DefaultMiniKv, MaxSatEngineArg, generate_completions, is_verbose, seed_from_u64,
 };
-use ledger_explorer::search::{Workload, replay_prefix, replay_strict, search};
-use ledger_explorer::{HistoryOracle, KeyValueSpec, Oracle, minimize_schedule};
+use ledger_explorer::search::Workload;
+use ledger_explorer::services::ServiceError;
+use ledger_explorer::services::{minimize_decisions, replay_prefix, replay_strict, search_first};
+use ledger_explorer::{HistoryOracle, KeyValueSpec, Oracle};
 use ledger_format::Hash;
 use ledger_sim::{Policy, ReplayViolation, RunConfig, RuntimeError, SimFault, Simulation};
 
@@ -266,7 +268,7 @@ fn run_sim(
         return Ok(ExitCode::SUCCESS);
     }
 
-    if let Some(finding) = search(&workload, &oracle, config, runs)? {
+    if let Some(finding) = search_first(&workload, &oracle, config, runs)? {
         if cli.json {
             println!(
                 "{}",
@@ -309,7 +311,7 @@ fn run_repro(
         let replay_result = replay_strict(&workload, seed_hash, decisions);
         let replayed = match replay_result {
             Ok(value) => value,
-            Err(RuntimeError::StrictReplay(violation)) => {
+            Err(ServiceError::Simulation(RuntimeError::StrictReplay(violation))) => {
                 return strict_violation_exit(cli, &violation);
             }
             Err(other) => return Err(other.into()),
@@ -342,7 +344,7 @@ fn run_repro(
     let replay_result = replay_strict(&workload, seed_hash, run.decisions.clone());
     let replayed = match replay_result {
         Ok(value) => value,
-        Err(RuntimeError::StrictReplay(violation)) => {
+        Err(ServiceError::Simulation(RuntimeError::StrictReplay(violation))) => {
             return strict_violation_exit(cli, &violation);
         }
         Err(other) => return Err(other.into()),
@@ -457,8 +459,8 @@ fn run_minimize(
         .policy(policy)
         .max_steps(max_steps)
         .build();
-    if let Some(finding) = search(&workload, &oracle, config, runs)? {
-        let report = minimize_schedule(&finding.run.decisions, |decisions| {
+    if let Some(finding) = search_first(&workload, &oracle, config, runs)? {
+        let report = minimize_decisions(&finding.run.decisions, |decisions| {
             replay_prefix(&workload, finding.seed, decisions.to_vec())
                 .map(|run| oracle.check(&run).violated)
                 .unwrap_or(false)

--- a/crates/ledger-cli/tests/cli_tasks.rs
+++ b/crates/ledger-cli/tests/cli_tasks.rs
@@ -318,15 +318,19 @@ fn ldfi_executes_top_hypothesis() {
             assert!(
                 matches!(
                     error,
-                    ledger_cli::ldfi_cmd::LdfiCmdError::Replay(
-                        ledger_explorer::search::FaultReplayError::StrictReplay(_)
+                    ledger_cli::ldfi_cmd::LdfiCmdError::Service(
+                        ledger_explorer::services::ServiceError::Replay(
+                            ledger_explorer::search::FaultReplayError::StrictReplay(_)
+                        )
                     )
                 ),
                 "ldfi must fail with a typed strict violation, got: {error:?}"
             );
             let violation = match error {
-                ledger_cli::ldfi_cmd::LdfiCmdError::Replay(
-                    ledger_explorer::search::FaultReplayError::StrictReplay(violation),
+                ledger_cli::ldfi_cmd::LdfiCmdError::Service(
+                    ledger_explorer::services::ServiceError::Replay(
+                        ledger_explorer::search::FaultReplayError::StrictReplay(violation),
+                    ),
                 ) => violation,
                 other => panic!("ldfi must fail with a typed strict violation, got: {other:?}"),
             };

--- a/crates/ledger-explorer/src/lib.rs
+++ b/crates/ledger-explorer/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod attest_uri;
 pub mod certs;
 pub mod coverage;
-pub mod diagnosis;
+mod diagnosis;
 pub mod faultspec_bridge;
 pub mod forensics;
 pub mod ldfi;
@@ -21,6 +21,7 @@ pub mod oracle;
 pub mod pbt;
 pub mod reference;
 pub mod search;
+pub mod services;
 pub mod solver;
 pub mod solver_cache;
 pub mod solver_state;
@@ -38,27 +39,21 @@ pub use certs::{
 pub use coverage::{
     CovError, CoverageBuilder, CoverageReport, RootRecord, to_jacoco, to_lcov, to_sarif,
 };
-pub use diagnosis::first_divergence;
-pub use forensics::{MotifLift, rank_motifs_by_lift};
 pub use ldfi::{FaultHypothesis, FaultableEvent, solve_with};
 pub use maxsat::LOWER_BOUND_METHOD;
-pub use memo::{CampaignMemo, MemoEntry, canonical_variant_bytes, hash_inputs, memo_key};
 pub use minimizer::{
     MemoError, MemoizedReplay, MinimizationReport, MinimizeError, MinimizedRepro, causal_slice,
     causal_slice_forward, ddmin, minimize_full, minimize_schedule,
 };
-pub use monitor::{LivenessMonitor, MonitorAction, MonitorOracle, OnlineMonitor, SafetyMonitor};
 pub use oracle::{
     AssertionOracle, CachedPropertyOracle, DifferentialOracle, ExactlyOnceValueOracle,
     HistoryOperation, HistoryOracle, KeyValueSpec, LinOperation, LinearizabilityOracle, Oracle,
     PropertyOracle, SequentialSpec, Verdict, compose_oracles, predicate_version,
 };
-pub use pbt::{InputsWorkload, PbtBridge};
 pub use search::{
-    CampaignPersist, CampaignReport, Finding, QuadBandit, QuadMutation, Workload, diff, escalate,
-    replay_prefix, replay_strict, replay_with_faults, run_bandit_campaign, run_campaign,
-    run_campaign_quad, run_feedback_campaign, run_feedback_campaign_with_state, run_joint_campaign,
-    run_joint_campaign_with_state, run_monitored_campaign, run_swarm_campaign, search,
+    CampaignReport, Finding, QuadBandit, QuadMutation, Workload, diff, replay_prefix,
+    replay_strict, replay_with_faults, run_bandit_campaign, run_campaign, run_campaign_quad,
+    run_feedback_campaign, run_feedback_campaign_with_state, run_swarm_campaign, search,
     search_input, search_input_energy,
 };
 pub use solver::MaxSatSolver;
@@ -67,10 +62,6 @@ pub use solver::{
     SolverError, cutoff, event_fault_cost, is_faultable, select_solver,
 };
 pub use solver_cache::{ClauseCache, WeightedClause};
-pub use solver_state::{
-    COST_MODEL_VERSION, PersistedClosure, PersistedHypothesis, SolverStateArtifact,
-    SolverStateError, fingerprint, load as load_solver_state, save as save_solver_state,
-};
 pub use support::{
     StaticSupportProvider, SupportError, SupportExpr, SupportOutcome, SupportProvider, all_of_ids,
     entry_ids_by,

--- a/crates/ledger-explorer/src/services.rs
+++ b/crates/ledger-explorer/src/services.rs
@@ -1,0 +1,168 @@
+//! Stable application services consumed by the CLI and the worker.
+//!
+//! Each service is one operation with explicit inputs and typed errors that
+//! preserve their sources. The services compose the search, solver, and
+//! certificate surfaces. Callers outside the explorer crate route through
+//! them instead of reaching into implementation modules.
+
+use crate::certs::{CampaignCertificate, CertError, ResolvedDependency};
+use crate::ldfi::{self, FaultHypothesis};
+use crate::maxsat;
+use crate::minimizer::{self, MinimizationReport, MinimizeError, MinimizedRepro};
+use crate::oracle::{Oracle, Verdict};
+use crate::search::{
+    self, CampaignReport, FaultReplayError, FaultReplayReport, Finding, SearchError, Workload,
+};
+use crate::solver::{SolverConfig, SolverError};
+use ledger_format::Hash;
+use ledger_journal::Journal;
+use ledger_sim::{RunConfig, RunResult, RuntimeError, SimFault};
+
+/// Typed failure of a service operation, preserving the source error.
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceError {
+    /// A search or campaign step failed.
+    #[error(transparent)]
+    Search(#[from] SearchError),
+    /// Strict replay rejected a decision stream.
+    #[error(transparent)]
+    Replay(#[from] FaultReplayError),
+    /// Fault-hypothesis solving failed.
+    #[error(transparent)]
+    Solve(#[from] SolverError),
+    /// Statement encoding, decoding, or validation failed.
+    #[error(transparent)]
+    Cert(#[from] CertError),
+    /// Minimization failed.
+    #[error(transparent)]
+    Minimize(#[from] MinimizeError),
+    /// A simulation failed outside a search or replay path.
+    #[error(transparent)]
+    Simulation(#[from] RuntimeError),
+    /// A journal could not be read.
+    #[error("journal error: {0}")]
+    Journal(#[from] ledger_journal::JournalError),
+}
+
+/// Run a multi-attempt campaign over one workload and oracle.
+pub fn run_campaign<W: Workload, O: Oracle>(
+    workload: &W,
+    oracle: &O,
+    config: RunConfig,
+    attempts: usize,
+) -> Result<CampaignReport, ServiceError> {
+    Ok(search::run_campaign(workload, oracle, config, attempts)?)
+}
+
+/// Find the first violating run over `attempts` seeded attempts.
+pub fn search_first<W: Workload, O: Oracle>(
+    workload: &W,
+    oracle: &O,
+    config: RunConfig,
+    attempts: usize,
+) -> Result<Option<Finding>, ServiceError> {
+    Ok(search::search(workload, oracle, config, attempts)?)
+}
+
+/// Strictly replay a recorded decision stream against a workload.
+pub fn replay_strict<W: Workload + ?Sized>(
+    workload: &W,
+    seed: Hash,
+    decisions: Vec<usize>,
+) -> Result<RunResult, ServiceError> {
+    Ok(search::replay_strict(workload, seed, decisions)?)
+}
+
+/// Lenient prefix replay for delta debugging only. It never satisfies a
+/// reproduction gate.
+pub fn replay_prefix<W: Workload + ?Sized>(
+    workload: &W,
+    seed: Hash,
+    decisions: Vec<usize>,
+) -> Result<RunResult, ServiceError> {
+    Ok(search::replay_prefix(workload, seed, decisions)?)
+}
+
+/// Solve the hazard of one verdict into ranked fault hypotheses.
+pub fn ldfi_solve(
+    journal: &Journal,
+    verdict: &Verdict,
+    config: &SolverConfig,
+) -> Result<Vec<FaultHypothesis>, ServiceError> {
+    let encoded = maxsat::encode_hazard(journal, verdict, config)?;
+    let mut solver = crate::solver::select_solver(config, &encoded);
+    Ok(ldfi::solve_with(solver.as_mut(), journal, verdict)?)
+}
+
+/// Convert one hypothesis into an executable fault schedule.
+pub fn schedule_from_hypothesis(hypothesis: &FaultHypothesis, journal: &Journal) -> Vec<SimFault> {
+    ldfi::hypothesis_to_schedule(hypothesis, journal)
+}
+
+/// Replay one fault schedule against a witness run under strict replay.
+pub fn replay_faults<W: Workload + ?Sized>(
+    workload: &W,
+    base: &Journal,
+    seed: Hash,
+    decisions: Vec<usize>,
+    schedule: Vec<SimFault>,
+) -> Result<FaultReplayReport, ServiceError> {
+    Ok(search::replay_with_faults(
+        workload, base, seed, decisions, schedule,
+    )?)
+}
+
+/// Minimize a decision stream under an oracle predicate (delta debugging).
+pub fn minimize_decisions(
+    decisions: &[usize],
+    oracle_check: impl Fn(&[usize]) -> bool,
+) -> MinimizationReport {
+    minimizer::minimize_schedule(decisions, oracle_check)
+}
+
+/// Minimize one finding end to end.
+pub fn minimize_finding<W: Workload, O: Oracle>(
+    workload: &W,
+    oracle: &O,
+    finding: &Finding,
+    generator: &str,
+) -> Result<MinimizedRepro, ServiceError> {
+    Ok(minimizer::minimize_full(
+        workload, oracle, finding, generator,
+    )?)
+}
+
+/// Emit a campaign certificate from a report.
+pub fn emit_statement(
+    report: &CampaignReport,
+    builder_id: &str,
+    dependencies: Vec<ResolvedDependency>,
+    run_config_digest: Hash,
+) -> Result<CampaignCertificate, ServiceError> {
+    Ok(CampaignCertificate::from_campaign(
+        report,
+        builder_id,
+        dependencies,
+        run_config_digest,
+    )?)
+}
+
+/// Parse a certificate from its JSON statement bytes.
+pub fn parse_statement(json: &str) -> Result<CampaignCertificate, ServiceError> {
+    Ok(CampaignCertificate::from_json(json)?)
+}
+
+/// Validate a statement's internal structure without a journal.
+pub fn validate_statement(certificate: &CampaignCertificate) -> Result<(), ServiceError> {
+    certificate.verify()?;
+    Ok(())
+}
+
+/// Bind a statement to a journal and validate the recorded cut.
+pub fn validate_cut_against_journal(
+    certificate: &CampaignCertificate,
+    journal: &Journal,
+) -> Result<(), ServiceError> {
+    certificate.verify_with_journal(journal)?;
+    Ok(())
+}

--- a/crates/ledger-explorer/tests/public_api_inventory.rs
+++ b/crates/ledger-explorer/tests/public_api_inventory.rs
@@ -1,0 +1,42 @@
+//! Public API inventory.
+//!
+//! The CLI and worker consume the explorer through the stable services in
+//! [`ledger_explorer::services`]. The crate root re-exports the reviewed
+//! contracts: search and campaign semantics, solver configuration, oracles,
+//! certificates, and the corpus reference surface.
+//!
+//! The import block below is the inventory: every reviewed name must
+//! resolve through the root or the services module, so removing any name
+//! from the public surface breaks the compile of this file. The names are
+//! intentionally unused here; their reachability is the assertion.
+
+#![expect(
+    unused_imports,
+    reason = "the import set is the compile-pinned public API inventory"
+)]
+
+use ledger_explorer::services::{
+    ServiceError, emit_statement, ldfi_solve, minimize_decisions, minimize_finding,
+    parse_statement, replay_faults, replay_prefix, replay_strict, run_campaign,
+    schedule_from_hypothesis, search_first, validate_cut_against_journal, validate_statement,
+};
+use ledger_explorer::{
+    AssertionOracle, CampaignCertificate, CampaignReport, CertError, ClauseCache, CoverageBuilder,
+    DifferentialOracle, Finding, HistoryOracle, HittingSetSolver, KeyValueSpec, LineagePolicy,
+    MaxSatSolver, MinimizationReport, MinimizeError, Oracle, PropertyOracle, QuadMutation,
+    RecordedSolverData, ResolvedDependency, SolverConfig, SolverEngine, SolverError,
+    StaticSupportProvider, Subject, SupportError, SupportExpr, Verdict, WeightedClause, Workload,
+    diff, replay_with_faults, run_campaign_quad, run_feedback_campaign, search_input,
+    select_solver, solve_with, to_jacoco, to_lcov, to_sarif,
+};
+
+/// The service error type is public and preserves its source chain, so CLI
+/// and worker failures keep the typed cause.
+#[test]
+fn service_error_is_public_and_typed() {
+    let name = std::any::type_name::<ServiceError>();
+    assert!(
+        name.contains("ServiceError"),
+        "service error must stay public: {name}"
+    );
+}

--- a/crates/ledger-explorer/tests/services.rs
+++ b/crates/ledger-explorer/tests/services.rs
@@ -1,0 +1,274 @@
+//! Service-level behavior: one happy path and one typed error path per
+//! service, asserting the source error survives the boundary.
+
+use ledger_explorer::services::{
+    ServiceError, emit_statement, ldfi_solve, minimize_decisions, parse_statement, replay_faults,
+    replay_prefix, replay_strict, run_campaign, schedule_from_hypothesis, search_first,
+    validate_cut_against_journal, validate_statement,
+};
+use ledger_explorer::solver::SolverConfig;
+use ledger_explorer::{CampaignReport, CertError, Finding, Oracle, PropertyOracle, Workload};
+use ledger_format::{EntryKind, Payload};
+use ledger_journal::Journal;
+use ledger_sim::{Instruction, Policy, RunConfig, RunResult, SimFault, Simulation};
+
+fn outcome_value(journal: &Journal) -> Option<u64> {
+    journal
+        .entries()
+        .filter(|entry| entry.data.kind == EntryKind::Outcome)
+        .find_map(|entry| match &entry.data.payload {
+            Payload::Number(value) => Some(*value),
+            _ => None,
+        })
+}
+
+/// A workload that journals one outcome value.
+struct OutcomeWorkload(u64);
+
+impl Workload for OutcomeWorkload {
+    fn programs(&self) -> Vec<Vec<Instruction>> {
+        vec![vec![
+            Instruction::Set(self.0),
+            Instruction::Outcome,
+            Instruction::Done,
+        ]]
+    }
+    fn history(&self, _run: &RunResult) -> Vec<ledger_explorer::oracle::HistoryOperation> {
+        Vec::new()
+    }
+}
+
+fn seed_bytes(seed: u64) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[0..8].copy_from_slice(&seed.to_le_bytes());
+    out
+}
+
+fn config(seed: u64) -> RunConfig {
+    RunConfig::builder()
+        .seed(seed_bytes(seed))
+        .policy(Policy::Random)
+        .max_steps(256)
+        .build()
+}
+
+fn final_is(expect: u64) -> PropertyOracle<impl Fn(&Journal) -> bool> {
+    PropertyOracle {
+        property: move |journal: &Journal| outcome_value(journal) == Some(expect),
+        name: format!("final value must be {expect}"),
+    }
+}
+
+#[test]
+fn run_campaign_happy_path_and_no_silent_errors() {
+    let workload = OutcomeWorkload(99);
+    let oracle = final_is(7);
+    let report: CampaignReport =
+        run_campaign(&workload, &oracle, config(1), 4).expect("campaign must run");
+    assert_eq!(report.runs_executed, 4);
+    assert!(!report.findings.is_empty(), "every run violates the oracle");
+}
+
+#[test]
+fn search_first_happy_path_and_empty_when_clean() {
+    let workload = OutcomeWorkload(7);
+    let oracle = final_is(7);
+    let finding: Option<Finding> =
+        search_first(&workload, &oracle, config(2), 4).expect("search must run");
+    assert!(finding.is_none(), "clean workload finds nothing");
+
+    let workload = OutcomeWorkload(99);
+    let oracle = final_is(7);
+    let finding: Option<Finding> =
+        search_first(&workload, &oracle, config(3), 4).expect("search must run");
+    let finding = finding.expect("violating workload must be found");
+    assert!(finding.verdict.violated);
+}
+
+#[test]
+fn replay_strict_pins_the_root_and_rejects_bad_decisions() {
+    let workload = OutcomeWorkload(7);
+    let run = Simulation::new(config(4), workload.programs())
+        .run()
+        .expect("base run must execute");
+    let replayed =
+        replay_strict(&workload, seed_bytes(4), run.decisions.clone()).expect("replay ok");
+    assert_eq!(replayed.journal.root_hash(), run.journal.root_hash());
+
+    let mut bad = run.decisions.clone();
+    if let Some(first) = bad.first_mut() {
+        // At the first step one task is ready, so a huge decision is
+        // outside the ready set and must be rejected as OutOfRange.
+        *first = usize::MAX;
+    }
+    let err = replay_strict(&workload, seed_bytes(4), bad).expect_err("out-of-range rejected");
+    assert!(
+        matches!(
+            err,
+            ServiceError::Simulation(ledger_sim::RuntimeError::StrictReplay(
+                ledger_sim::ReplayViolation::OutOfRange { .. }
+            ))
+        ),
+        "typed strict violation: {err:?}"
+    );
+}
+
+#[test]
+fn replay_prefix_is_available_but_must_not_satisfy_a_gate() {
+    let workload = OutcomeWorkload(7);
+    let run = Simulation::new(config(5), workload.programs())
+        .run()
+        .expect("base run must execute");
+    let replayed =
+        replay_prefix(&workload, seed_bytes(5), run.decisions.clone()).expect("prefix replay runs");
+    assert_eq!(replayed.journal.root_hash(), run.journal.root_hash());
+}
+
+/// A two-task workload: the writer sends one fresh value; the reader
+/// journals it as its outcome. Dropping the send breaks the outcome.
+struct SendWorkload;
+
+impl Workload for SendWorkload {
+    fn programs(&self) -> Vec<Vec<Instruction>> {
+        vec![
+            vec![
+                Instruction::SendTimed {
+                    to: 1,
+                    payload: 7,
+                    delay: 1,
+                },
+                Instruction::Done,
+            ],
+            vec![
+                Instruction::Receive,
+                Instruction::Outcome,
+                Instruction::Done,
+            ],
+        ]
+    }
+    fn history(&self, _run: &RunResult) -> Vec<ledger_explorer::oracle::HistoryOperation> {
+        Vec::new()
+    }
+}
+
+#[test]
+fn ldfi_solve_ranks_hypotheses_from_a_violation() {
+    let workload = SendWorkload;
+    let oracle = final_is(7);
+    let base = Simulation::new(config(6), workload.programs())
+        .run()
+        .expect("base run must execute");
+    assert!(
+        !oracle.check(&base).violated,
+        "baseline outcome must be fresh"
+    );
+    let send_id = base
+        .journal
+        .entries()
+        .find(|entry| entry.data.kind == EntryKind::Send)
+        .expect("probe journal has the send")
+        .id;
+    let faulted = Simulation::new(
+        config(6).with_fault_schedule(vec![SimFault::Drop(send_id)]),
+        workload.programs(),
+    )
+    .run()
+    .expect("faulted run must execute");
+    let verdict = oracle.check(&faulted);
+    assert!(verdict.violated, "dropping the send must break the outcome");
+    let solver_config = SolverConfig {
+        max_horizon: Some(16),
+        ..SolverConfig::default()
+    };
+    let hypotheses = ldfi_solve(&faulted.journal, &verdict, &solver_config).expect("solve ok");
+    assert!(!hypotheses.is_empty(), "a violation yields hypotheses");
+    let schedule = schedule_from_hypothesis(&hypotheses[0], &faulted.journal);
+    assert!(
+        !schedule.is_empty(),
+        "the top hypothesis maps to a schedule"
+    );
+    let report = replay_faults(
+        &workload,
+        &faulted.journal,
+        seed_bytes(6),
+        faulted.decisions.clone(),
+        schedule,
+    )
+    .expect("fault replay runs");
+    assert!(
+        !report.applied.is_empty(),
+        "the critical send drop must be reported applied"
+    );
+}
+
+#[test]
+fn minimize_decisions_reduces_a_monotone_predicate() {
+    let decisions: Vec<usize> = (0..8).collect();
+    // The predicate is true only when the full set is present, so ddmin
+    // cannot shrink it further.
+    let report = minimize_decisions(&decisions, |candidate| candidate.len() == decisions.len());
+    assert_eq!(report.minimized_count, 8);
+    // A predicate true for any non-empty suffix shrinks to one step.
+    let report = minimize_decisions(&decisions, |candidate| !candidate.is_empty());
+    assert_eq!(report.minimized_count, 1);
+}
+
+#[test]
+fn emit_parse_validate_round_trip() {
+    let report: CampaignReport =
+        run_campaign(&OutcomeWorkload(99), &final_is(7), config(7), 1).expect("campaign must run");
+    let certificate =
+        emit_statement(&report, "builder", Vec::new(), [1u8; 32]).expect("statement must emit");
+    let json = certificate.to_json().expect("serialize");
+    let parsed = parse_statement(&json).expect("statement must parse");
+    validate_statement(&parsed).expect("statement must validate");
+
+    // Lineage-only reports cannot emit a certifiable statement.
+    let mut lineage_only = Journal::new();
+    lineage_only
+        .append(
+            EntryKind::Epoch,
+            0,
+            [],
+            Payload::Text("lineage-only".into()),
+        )
+        .expect("append lineage marker");
+    let findings: Vec<Finding> = report
+        .findings
+        .into_iter()
+        .map(|mut finding| {
+            finding.run.journal = lineage_only.clone();
+            finding
+        })
+        .collect();
+    let lineage_only = CampaignReport { findings, ..report };
+    let err = emit_statement(&lineage_only, "builder", Vec::new(), [1u8; 32])
+        .expect_err("lineage-only journals must be rejected");
+    assert!(
+        matches!(err, ServiceError::Cert(CertError::Verification(_))),
+        "typed cert error: {err:?}"
+    );
+
+    let err = parse_statement("{not json").expect_err("malformed json rejected");
+    assert!(
+        matches!(err, ServiceError::Cert(_)),
+        "typed parse error: {err:?}"
+    );
+}
+
+#[test]
+fn validate_cut_against_journal_rejects_zero_digest_binding() {
+    let report: CampaignReport =
+        run_campaign(&OutcomeWorkload(99), &final_is(99), config(8), 1).expect("campaign must run");
+    let mut certificate =
+        emit_statement(&report, "builder", Vec::new(), [1u8; 32]).expect("statement must emit");
+    // A zero subject digest never binds to any journal in journal mode.
+    certificate.subject.digest = [0u8; 32];
+    let journal = Journal::new();
+    let err =
+        validate_cut_against_journal(&certificate, &journal).expect_err("zero digest rejected");
+    assert!(
+        matches!(err, ServiceError::Cert(CertError::Verification(_))),
+        "typed binding error: {err:?}"
+    );
+}

--- a/crates/ledger-worker/src/worker.rs
+++ b/crates/ledger-worker/src/worker.rs
@@ -45,7 +45,7 @@ pub enum WorkerError {
     },
     /// The explorer pre-run campaign failed.
     #[error(transparent)]
-    Campaign(#[from] ledger_explorer::search::SearchError),
+    Campaign(#[from] ledger_explorer::services::ServiceError),
     /// The deterministic simulation run failed.
     #[error("simulation failed: {0}")]
     Sim(#[from] ledger_sim::RuntimeError),
@@ -289,7 +289,7 @@ pub fn execute_task(task: crate::queue::Task) -> Result<WorkerResult, WorkerErro
     let workload = workload_for(&task.workload);
     let oracle = AlwaysPassOracle;
     let campaign =
-        ledger_explorer::search::run_campaign(&workload, &oracle, task.run_config.clone(), 1)?;
+        ledger_explorer::services::run_campaign(&workload, &oracle, task.run_config.clone(), 1)?;
     let campaign_findings = campaign.findings.len();
     let run = Simulation::new(task.run_config.clone(), workload.programs()).run()?;
     Ok(WorkerResult {


### PR DESCRIPTION
Four lanes, one commit each, completing the Wave 2 workstreams of the remediation plan.

**A1 - typed support semantics** (`feat(support)`): `SupportExpr` (AllOf/AnyOf/Opaque) with non-empty constructors, a versioned `SupportProvider` whose digest folds into solver cache keys and the solver-state fingerprint, and explicit support models for every corpus fixture. Journal parent edges no longer masquerade as support.

**A3 - non-vacuous LDFI + PBT gates** (`feat(gates)`): the old aggregate-ratio efficiency test becomes the DR-0003 gate - ten fault-dependent fixtures (baselines pass; one eligible applied fault breaks the run; strict replay reproduces; final rerun passes), 20 predeclared paired seeds, budget B=16, per-case median costs, geometric-mean corpus ratio with a 5.0 floor, no case below 1.0, 0.8 per-case win rate, byte-identical pre-registered artifacts. PBT gate finds its planted trigger within budget and reproduces strictly. Measured: per-case speedups 2.4x-17x.

**A4 - capability closure** (`feat(gates)`): each named capability carries a contract, a no-op-failing negative control, and a measurement - incremental solver state (snapshot/warm/foreign-artifact rejection), differential lineage (walked-entries counter), SAMC pre-pruning (selectivity, determinism, idempotence), and the end-to-end chain scaling to 10^6 entries in 1.7s release against the 60s budget with a closure-scaled horizon.

**H1 - application services** (`feat(services)`): thirteen services over the existing typed errors (transparent `ServiceError`, no parallel types); CLI and worker migrated onto them; the explorer public surface curated to the reviewed contracts with a compile-pinned inventory test.

**Verification:** fmt, workspace clippy `-D warnings`, 998/998 workspace tests (pg_queue excluded - needs live Postgres), ledger-lint 0, xtask licenses, no_std checks, ldgr-rt feature combos.