### PR TITLE
feat(identity): complete ExecutionIdentity and artifact binding

### DIFF
--- a/crates/ledger-cli/src/scaffold.rs
+++ b/crates/ledger-cli/src/scaffold.rs
@@ -157,6 +157,7 @@ fn default_manifest() -> Result<Vec<u8>, ScaffoldError> {
         journal_root: [0u8; 32],
         entry_count: 0,
         actor_heads: BTreeMap::new(),
+        execution_identity: None,
         extensions: BTreeMap::new(),
     };
     manifest

--- a/crates/ledger-cli/tests/cert_cmd.rs
+++ b/crates/ledger-cli/tests/cert_cmd.rs
@@ -31,8 +31,9 @@ fn write_cert(path: &PathBuf, json: &str) {
 #[test]
 fn cert_verify_human_valid() {
     let report = make_report(10);
-    let cert = CampaignCertificate::from_campaign(&report, "builder-test", Vec::new(), [1u8; 32])
-        .expect("valid report must create a certificate");
+    let cert =
+        CampaignCertificate::from_campaign(&report, "builder-test", Vec::new(), [1u8; 32], None)
+            .expect("valid report must create a certificate");
     let json = cert.to_json().unwrap();
     let path = temp_path("valid-human");
     write_cert(&path, &json);
@@ -75,8 +76,9 @@ fn cert_verify_json_valid() {
         name: "dep-a".into(),
         digest: [2u8; 32],
     }];
-    let mut cert = CampaignCertificate::from_campaign(&report, "builder-json", deps, [9u8; 32])
-        .expect("valid report must create a certificate");
+    let mut cert =
+        CampaignCertificate::from_campaign(&report, "builder-json", deps, [9u8; 32], None)
+            .expect("valid report must create a certificate");
     cert.solver_data = Some(RecordedSolverData {
         cut: vec![[3u8; 32], [4u8; 32]],
         recorded_lower_bound: 1,
@@ -124,8 +126,9 @@ fn cert_verify_json_valid() {
 #[test]
 fn cert_verify_tampered_predicate_fails() {
     let report = make_report(10);
-    let cert = CampaignCertificate::from_campaign(&report, "builder-test", Vec::new(), [1u8; 32])
-        .expect("valid report must create a certificate");
+    let cert =
+        CampaignCertificate::from_campaign(&report, "builder-test", Vec::new(), [1u8; 32], None)
+            .expect("valid report must create a certificate");
     let mut json = cert.to_json().unwrap();
     // tamper predicateType
     let tampered = format!(
@@ -147,8 +150,9 @@ fn cert_verify_tampered_predicate_fails() {
 #[test]
 fn cert_verify_preserves_journal_open_error_source() {
     let report = make_report(10);
-    let cert = CampaignCertificate::from_campaign(&report, "builder-test", Vec::new(), [1u8; 32])
-        .expect("valid report must create a certificate");
+    let cert =
+        CampaignCertificate::from_campaign(&report, "builder-test", Vec::new(), [1u8; 32], None)
+            .expect("valid report must create a certificate");
     let cert_path = temp_path("journal-source-cert");
     write_cert(
         &cert_path,

--- a/crates/ledger-cli/tests/cli_tasks.rs
+++ b/crates/ledger-cli/tests/cli_tasks.rs
@@ -876,7 +876,7 @@ fn cert_verify_journal_mode_valid() {
         monitors: Vec::new(),
         memo_hits: 0,
     };
-    let cert = CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [9u8; 32])
+    let cert = CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [9u8; 32], None)
         .expect("valid report must create a certificate");
     let cert_path = dir.join("cert.json");
     std::fs::write(&cert_path, cert.to_json().unwrap()).unwrap();
@@ -951,7 +951,7 @@ fn cert_verify_journal_mode_wrong_root() {
         monitors: Vec::new(),
         memo_hits: 0,
     };
-    let cert = CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [9u8; 32])
+    let cert = CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [9u8; 32], None)
         .expect("valid report must create a certificate");
     let cert_path = dir.join("cert.json");
     std::fs::write(&cert_path, cert.to_json().unwrap()).unwrap();
@@ -976,8 +976,9 @@ fn cert_verify_human_recorded_solver_data_label() {
         monitors: Vec::new(),
         memo_hits: 0,
     };
-    let mut cert = CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [1u8; 32])
-        .expect("valid report must create a certificate");
+    let mut cert =
+        CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [1u8; 32], None)
+            .expect("valid report must create a certificate");
     cert.solver_data = Some(RecordedSolverData {
         cut: vec![[3u8; 32]],
         recorded_lower_bound: 2,
@@ -1051,7 +1052,7 @@ fn cert_verify_rejects_oversized_via_bounded_reader() {
         monitors: Vec::new(),
         memo_hits: 0,
     };
-    let cert = CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [1u8; 32])
+    let cert = CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [1u8; 32], None)
         .expect("valid report must create a certificate");
     let json = cert.to_json().unwrap();
     assert!(json.len() < 1024 * 1024, "base cert must be small");

--- a/crates/ledger-explorer/build.rs
+++ b/crates/ledger-explorer/build.rs
@@ -1,0 +1,24 @@
+//! Emit compile-time build facts for execution identity.
+//!
+//! The target triple and build profile are captured here and re-emitted as
+//! rustc env vars so the identity capture in `src/identity.rs` reads them
+//! with `option_env!`. The other build facts (revision, dirty state,
+//! toolchain) are consumed directly from the `LDGR_*` build environment by
+//! `option_env!` in `src/identity.rs`.
+// ledger-lint:allow:env::var (build script reads cargo metadata, not simulation code)
+
+use std::env;
+
+fn main() {
+    if let Ok(target) = env::var("TARGET") {
+        println!("cargo:rustc-env=LDGR_TARGET={target}");
+    }
+    if let Ok(profile) = env::var("PROFILE") {
+        println!("cargo:rustc-env=LDGR_BUILD_PROFILE={profile}");
+    }
+    println!("cargo:rerun-if-env-changed=TARGET");
+    println!("cargo:rerun-if-env-changed=PROFILE");
+    println!("cargo:rerun-if-env-changed=LDGR_ENGINE_SHA");
+    println!("cargo:rerun-if-env-changed=LDGR_DIRTY");
+    println!("cargo:rerun-if-env-changed=LDGR_TOOLCHAIN");
+}

--- a/crates/ledger-explorer/examples/gen_corpus.rs
+++ b/crates/ledger-explorer/examples/gen_corpus.rs
@@ -33,6 +33,7 @@ fn main() {
             journal_root: finding.run.journal.root_hash(),
             entry_count: finding.run.journal.len() as u64,
             actor_heads,
+            execution_identity: None,
             extensions: BTreeMap::new(),
         };
         let bytes = manifest.to_canonical_bytes().expect("manifest encodes");

--- a/crates/ledger-explorer/examples/gen_corpus_v2.rs
+++ b/crates/ledger-explorer/examples/gen_corpus_v2.rs
@@ -30,6 +30,7 @@ fn main() {
             journal_root: finding.run.journal.root_hash(),
             entry_count: finding.run.journal.len() as u64,
             actor_heads,
+            execution_identity: None,
             extensions: BTreeMap::new(),
         };
         let bytes = manifest.to_canonical_bytes().expect("manifest encodes");

--- a/crates/ledger-explorer/examples/nightly_swarm_campaign.rs
+++ b/crates/ledger-explorer/examples/nightly_swarm_campaign.rs
@@ -167,6 +167,7 @@ fn build_manifest(finding: &Finding) -> RunManifest {
         journal_root: finding.run.journal.root_hash(),
         entry_count: finding.run.journal.len() as u64,
         actor_heads,
+        execution_identity: None,
         extensions: BTreeMap::new(),
     }
 }
@@ -330,7 +331,7 @@ fn drive(args: &Args) -> Result<(), String> {
         let digest = run_config_digest(&base)?;
         let builder_id = builder_id();
         report
-            .write_certificate(&cert_path, digest, &builder_id)
+            .write_certificate(&cert_path, digest, &builder_id, None)
             .map_err(|error| format!("certificate emit: {error}"))?;
         println!("certificate written to {}", cert_path.display());
     }

--- a/crates/ledger-explorer/src/certs.rs
+++ b/crates/ledger-explorer/src/certs.rs
@@ -117,6 +117,13 @@ pub struct CampaignCertificate {
     pub findings_count: usize,
     pub solver_data: Option<RecordedSolverData>,
     pub statistical: Option<StatisticalBound>,
+    /// Execution-identity digest of the run that produced this statement.
+    ///
+    /// `None` on certificates emitted without identity binding; the
+    /// identity-aware journal verification ([`Self::verify_with_journal_and_identity`])
+    /// treats a present-but-unmatched digest as a failure before any root
+    /// comparison.
+    pub execution_identity: Option<Hash>,
 }
 
 #[derive(Debug, Error)]
@@ -260,12 +267,14 @@ impl CampaignCertificate {
         builder_id: &str,
         deps: Vec<ResolvedDependency>,
         run_config_digest: Hash,
+        execution_identity: Option<Hash>,
     ) -> Result<Self, CertError> {
         Self::from_campaign_with(
             report,
             builder_id,
             deps,
             run_config_digest,
+            execution_identity,
             LineagePolicy::Strict,
         )
     }
@@ -276,6 +285,7 @@ impl CampaignCertificate {
         builder_id: &str,
         deps: Vec<ResolvedDependency>,
         run_config_digest: Hash,
+        execution_identity: Option<Hash>,
         policy: LineagePolicy,
     ) -> Result<Self, CertError> {
         if policy == LineagePolicy::Strict {
@@ -283,7 +293,13 @@ impl CampaignCertificate {
                 check_lineage_not_certifiable(&finding.run.journal)?;
             }
         }
-        Self::from_campaign_inner(report, builder_id, deps, run_config_digest)
+        Self::from_campaign_inner(
+            report,
+            builder_id,
+            deps,
+            run_config_digest,
+            execution_identity,
+        )
     }
 
     fn from_campaign_inner(
@@ -291,6 +307,7 @@ impl CampaignCertificate {
         builder_id: &str,
         deps: Vec<ResolvedDependency>,
         run_config_digest: Hash,
+        execution_identity: Option<Hash>,
     ) -> Result<Self, CertError> {
         let subject = if let Some(f) = report.findings.first() {
             Subject {
@@ -321,6 +338,7 @@ impl CampaignCertificate {
             findings_count: report.findings.len(),
             solver_data: None,
             statistical,
+            execution_identity,
         };
         certificate.verify()?;
         Ok(certificate)
@@ -381,6 +399,10 @@ impl CampaignCertificate {
             .map(|x| serde_json::json!({"name":x.name,"digest":{"blake3":hash_to_hex(&x.digest)}}))
             .collect();
         let mut p = serde_json::json!({"buildDefinition":{"buildType":self.build_type,"externalParameters":{"runConfigDigest":hash_to_hex(&self.external_parameters_digest)},"resolvedDependencies":deps_json},"runDetails":{"builder":{"id":self.builder_id},"metadata":{"runsExecuted":self.runs_executed,"findingsCount":self.findings_count}}});
+        if let Some(identity) = &self.execution_identity {
+            p["buildDefinition"]["externalParameters"]["executionIdentity"] =
+                serde_json::json!(hash_to_hex(identity));
+        }
         if let Some(data) = &self.solver_data {
             let mut solver_json = serde_json::json!({"cut":data.cut.iter().map(hash_to_hex).collect::<Vec<_>>(),"recordedLowerBound":data.recorded_lower_bound,"method":data.method});
             if let Some(horizon) = data.horizon {
@@ -454,10 +476,20 @@ impl CampaignCertificate {
             external_parameters,
             "externalParameters",
             &["runConfigDigest"],
-            &[],
+            &["executionIdentity"],
         )?;
         let run_digest = hex_to_hash(get_str(external_parameters, "runConfigDigest")?)
             .map_err(CertError::Schema)?;
+        let execution_identity = match external_parameters.get("executionIdentity") {
+            Some(value) => {
+                let text = value
+                    .as_str()
+                    .ok_or_else(|| CertError::Schema("executionIdentity".into()))?;
+                check_string_bytes(text, "executionIdentity")?;
+                Some(hex_to_hash(text).map_err(CertError::Schema)?)
+            }
+            None => None,
+        };
         let deps_arr = get_arr(bd, "resolvedDependencies")?;
         if deps_arr.len() > MAX_RESOLVED_DEPENDENCIES {
             return Err(CertError::Schema(format!(
@@ -571,6 +603,7 @@ impl CampaignCertificate {
             findings_count,
             solver_data,
             statistical,
+            execution_identity,
         })
     }
 
@@ -764,6 +797,41 @@ impl CampaignCertificate {
     pub fn verify_with_journal(&self, journal: &Journal) -> Result<(), CertError> {
         self.verify_with_journal_with(journal, LineagePolicy::Strict)
     }
+
+    /// Validate and bind the certificate to a journal, gated on execution
+    /// identity.
+    ///
+    /// The identity gate runs before any root comparison: a certificate that
+    /// carries an identity digest must match the expected digest of the run
+    /// that produced the journal, and a digest present on only one side is
+    /// treated as incomplete and rejected. When both sides carry no identity
+    /// the legacy comparison path is used.
+    pub fn verify_with_journal_and_identity(
+        &self,
+        journal: &Journal,
+        expected_identity: Option<Hash>,
+    ) -> Result<(), CertError> {
+        match (self.execution_identity, expected_identity) {
+            (Some(certificate), Some(expected)) if certificate == expected => {}
+            (Some(_), Some(_)) => {
+                return Err(CertError::Verification(
+                    "execution identity mismatch: certificate and run disagree".into(),
+                ));
+            }
+            (Some(_), None) => {
+                return Err(CertError::Verification(
+                    "execution identity incomplete: run carries no identity".into(),
+                ));
+            }
+            (None, Some(_)) => {
+                return Err(CertError::Verification(
+                    "execution identity incomplete: certificate carries no identity".into(),
+                ));
+            }
+            (None, None) => {}
+        }
+        self.verify_with_journal(journal)
+    }
 }
 
 impl CampaignReport {
@@ -783,6 +851,7 @@ impl CampaignReport {
         path: &Path,
         run_config_digest: Hash,
         builder_id: &str,
+        execution_identity: Option<Hash>,
     ) -> Result<(), CertError> {
         if let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
@@ -793,8 +862,13 @@ impl CampaignReport {
                 source,
             })?;
         }
-        let cert =
-            CampaignCertificate::from_campaign(self, builder_id, Vec::new(), run_config_digest)?;
+        let cert = CampaignCertificate::from_campaign(
+            self,
+            builder_id,
+            Vec::new(),
+            run_config_digest,
+            execution_identity,
+        )?;
         let json = cert.to_json()?;
         check_cert_bytes(json.len())?;
         std::fs::write(path, json).map_err(|source| CertError::Io {
@@ -876,7 +950,7 @@ mod tests {
                 digest: [1u8; 32],
             },
         ];
-        let c = CampaignCertificate::from_campaign(&r, "builder-1", deps, [9u8; 32]).unwrap();
+        let c = CampaignCertificate::from_campaign(&r, "builder-1", deps, [9u8; 32], None).unwrap();
         let j = c.to_json().unwrap();
         let b = CampaignCertificate::from_json(&j).unwrap();
         assert_eq!(c.subject, b.subject);
@@ -886,8 +960,9 @@ mod tests {
 
     #[test]
     fn emitted_json_limit_preserves_round_trip_boundary() {
-        let base = CampaignCertificate::from_campaign(&empty(10), "builder", Vec::new(), [9u8; 32])
-            .expect("base certificate must be valid");
+        let base =
+            CampaignCertificate::from_campaign(&empty(10), "builder", Vec::new(), [9u8; 32], None)
+                .expect("base certificate must be valid");
         let with_dependency_name_size = |name_bytes: usize| {
             let mut certificate = base.clone();
             certificate.resolved_dependencies = (0..MAX_RESOLVED_DEPENDENCIES)
@@ -954,7 +1029,7 @@ mod tests {
         // Writing onto an existing directory fails deterministically on
         // unix with IsADirectory: the write arm keeps the io source.
         let err = empty(1)
-            .write_certificate(&dir, [0u8; 32], "builder")
+            .write_certificate(&dir, [0u8; 32], "builder", None)
             .unwrap_err();
         match &err {
             CertError::Io {
@@ -989,7 +1064,7 @@ mod tests {
         std::fs::write(&blocker, b"x").expect("write blocker file");
         let cert_path = blocker.join("cert.json");
         let err = empty(1)
-            .write_certificate(&cert_path, [0u8; 32], "builder")
+            .write_certificate(&cert_path, [0u8; 32], "builder", None)
             .unwrap_err();
         match &err {
             CertError::Io {
@@ -1026,7 +1101,7 @@ mod tests {
         let cert_path = dir.join("cert.json");
         let builder = "x".repeat(CERT_MAX_BYTES + 1);
         let error = empty(1)
-            .write_certificate(&cert_path, [9u8; 32], &builder)
+            .write_certificate(&cert_path, [9u8; 32], &builder, None)
             .expect_err("oversized certificate input must fail");
         assert!(
             matches!(error, CertError::Schema(_) | CertError::Serialization(_)),
@@ -1043,7 +1118,7 @@ mod tests {
         let dir = unique_cert_dir("rt");
         let cert_path = dir.join("cert.json");
         with_finding()
-            .write_certificate(&cert_path, [9u8; 32], "builder")
+            .write_certificate(&cert_path, [9u8; 32], "builder", None)
             .expect("write certificate");
         let bytes = std::fs::read(&cert_path).expect("read certificate");
         let text = String::from_utf8(bytes).expect("certificate must be utf8");
@@ -1055,7 +1130,8 @@ mod tests {
     #[test]
     fn verify_rejects_wrong_predicate_type() {
         let mut c =
-            CampaignCertificate::from_campaign(&empty(10), "b", Vec::new(), [1u8; 32]).unwrap();
+            CampaignCertificate::from_campaign(&empty(10), "b", Vec::new(), [1u8; 32], None)
+                .unwrap();
         c.predicate_type = format!(
             "{}/attestations/wrong/v1",
             crate::attest_uri::attestation_base()
@@ -1072,20 +1148,140 @@ mod tests {
 
     #[test]
     fn verify_rejects_zero_subject_with_findings() {
-        let mut c = CampaignCertificate::from_campaign(&with_finding(), "b", Vec::new(), [1u8; 32])
-            .expect("valid campaign must create a certificate");
+        let mut c =
+            CampaignCertificate::from_campaign(&with_finding(), "b", Vec::new(), [1u8; 32], None)
+                .expect("valid campaign must create a certificate");
         c.subject.digest = [0u8; 32];
         assert!(matches!(c.verify(), Err(CertError::Verification(_))));
     }
 
     #[test]
+    fn identity_gate_rejects_disagreeing_statement_and_run() {
+        // Statement and run disagree: the gate fails before any root
+        // comparison.
+        let certificate = CampaignCertificate::from_campaign(
+            &with_finding(),
+            "b",
+            Vec::new(),
+            [1u8; 32],
+            Some([0xaa; 32]),
+        )
+        .expect("certificate with identity must build");
+        let journal = &with_finding().findings[0].run.journal;
+        let error = certificate
+            .verify_with_journal_and_identity(journal, Some([0xbb; 32]))
+            .expect_err("disagreeing identity must fail");
+        assert!(matches!(error, CertError::Verification(_)));
+    }
+
+    #[test]
+    fn identity_gate_rejects_incomplete_sides() {
+        let certificate = CampaignCertificate::from_campaign(
+            &with_finding(),
+            "b",
+            Vec::new(),
+            [1u8; 32],
+            Some([0xaa; 32]),
+        )
+        .expect("certificate with identity must build");
+        let journal = &with_finding().findings[0].run.journal;
+        // Certificate carries identity, run carries none: incomplete.
+        let error = certificate
+            .verify_with_journal_and_identity(journal, None)
+            .expect_err("run without identity must fail");
+        assert!(matches!(error, CertError::Verification(_)));
+
+        // Run carries identity, certificate carries none: incomplete.
+        let legacy =
+            CampaignCertificate::from_campaign(&with_finding(), "b", Vec::new(), [1u8; 32], None)
+                .expect("legacy certificate must build");
+        let error = legacy
+            .verify_with_journal_and_identity(journal, Some([0xaa; 32]))
+            .expect_err("certificate without identity must fail");
+        assert!(matches!(error, CertError::Verification(_)));
+    }
+
+    #[test]
+    fn identity_gate_passes_when_both_sides_match_or_are_absent() {
+        let certificate = CampaignCertificate::from_campaign(
+            &with_finding(),
+            "b",
+            Vec::new(),
+            [1u8; 32],
+            Some([0xaa; 32]),
+        )
+        .expect("certificate with identity must build");
+        let journal = &with_finding().findings[0].run.journal;
+        // Matching identity proceeds to the normal journal binding (subject
+        // digest equals the journal root from with_finding).
+        assert!(
+            certificate
+                .verify_with_journal_and_identity(journal, Some([0xaa; 32]))
+                .is_ok()
+        );
+        // Both sides absent: the legacy comparison path is unchanged.
+        let legacy =
+            CampaignCertificate::from_campaign(&with_finding(), "b", Vec::new(), [1u8; 32], None)
+                .expect("legacy certificate must build");
+        assert!(
+            legacy
+                .verify_with_journal_and_identity(journal, None)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn identity_json_round_trips() {
+        let certificate = CampaignCertificate::from_campaign(
+            &with_finding(),
+            "b",
+            Vec::new(),
+            [1u8; 32],
+            Some([0xaa; 32]),
+        )
+        .expect("certificate with identity must build");
+        let json = certificate.to_json().expect("certificate serializes");
+        assert!(json.contains("executionIdentity"));
+        let decoded = CampaignCertificate::from_json(&json).expect("certificate parses");
+        assert_eq!(decoded.execution_identity, Some([0xaa; 32]));
+        // Legacy JSON without the field parses to None. The identity field
+        // lives under externalParameters; removing the serialized value must
+        // leave a valid legacy statement.
+        let value: serde_json::Value = serde_json::from_str(&json).expect("json parses");
+        let mut params = value["predicate"]["buildDefinition"]["externalParameters"]
+            .as_object()
+            .expect("externalParameters is an object")
+            .clone();
+        params.remove("executionIdentity");
+        let legacy_json = serde_json::to_string(&serde_json::json!({
+            "_type": value["_type"],
+            "subject": value["subject"],
+            "predicateType": value["predicateType"],
+            "predicate": {
+                "buildDefinition": {
+                    "buildType": value["predicate"]["buildDefinition"]["buildType"],
+                    "externalParameters": params,
+                    "resolvedDependencies": value["predicate"]["buildDefinition"]
+                        ["resolvedDependencies"],
+                },
+                "runDetails": value["predicate"]["runDetails"],
+            },
+        }))
+        .expect("legacy json builds");
+        let legacy = CampaignCertificate::from_json(&legacy_json).expect("legacy statement parses");
+        assert_eq!(legacy.execution_identity, None);
+    }
+
+    #[test]
     fn verify_rejects_absent_or_malformed_subject() {
-        let mut c = CampaignCertificate::from_campaign(&with_finding(), "b", Vec::new(), [1u8; 32])
-            .expect("valid campaign must create a certificate");
+        let mut c =
+            CampaignCertificate::from_campaign(&with_finding(), "b", Vec::new(), [1u8; 32], None)
+                .expect("valid campaign must create a certificate");
         c.subject.name = "  ".into();
         assert!(matches!(c.verify(), Err(CertError::Verification(_))));
         let mut c =
-            CampaignCertificate::from_campaign(&empty(10), "b", Vec::new(), [1u8; 32]).unwrap();
+            CampaignCertificate::from_campaign(&empty(10), "b", Vec::new(), [1u8; 32], None)
+                .unwrap();
         c.subject.digest = [7u8; 32];
         assert!(
             matches!(c.verify(), Err(CertError::Verification(_))),
@@ -1095,9 +1291,14 @@ mod tests {
 
     #[test]
     fn statement_validation_rejects_empty_solver_data_cut() {
-        let mut certificate =
-            CampaignCertificate::from_campaign(&with_finding(), "builder", Vec::new(), [1u8; 32])
-                .expect("valid campaign must create a certificate");
+        let mut certificate = CampaignCertificate::from_campaign(
+            &with_finding(),
+            "builder",
+            Vec::new(),
+            [1u8; 32],
+            None,
+        )
+        .expect("valid campaign must create a certificate");
         certificate.solver_data = Some(RecordedSolverData {
             cut: Vec::new(),
             recorded_lower_bound: 0,
@@ -1124,7 +1325,7 @@ mod tests {
     #[test]
     fn from_json_rejects_wrong_type_and_multiple_subjects() {
         let certificate =
-            CampaignCertificate::from_campaign(&empty(10), "builder", Vec::new(), [1u8; 32])
+            CampaignCertificate::from_campaign(&empty(10), "builder", Vec::new(), [1u8; 32], None)
                 .expect("valid campaign must create a certificate");
         let mut value: serde_json::Value =
             serde_json::from_str(&certificate.to_json().expect("certificate must serialize"))
@@ -1146,9 +1347,14 @@ mod tests {
 
     #[test]
     fn from_json_rejects_empty_cut_duplicate_cut_and_invalid_horizon() {
-        let certificate =
-            CampaignCertificate::from_campaign(&with_finding(), "builder", Vec::new(), [1u8; 32])
-                .expect("valid campaign must create a certificate");
+        let certificate = CampaignCertificate::from_campaign(
+            &with_finding(),
+            "builder",
+            Vec::new(),
+            [1u8; 32],
+            None,
+        )
+        .expect("valid campaign must create a certificate");
         let mut value: serde_json::Value =
             serde_json::from_str(&certificate.to_json().expect("certificate must serialize"))
                 .expect("certificate JSON must parse");
@@ -1207,7 +1413,7 @@ mod tests {
             memo_hits: 0,
         };
         let mut certificate =
-            CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [1u8; 32])
+            CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [1u8; 32], None)
                 .expect("valid campaign must create a certificate");
         certificate.solver_data = Some(RecordedSolverData {
             recorded_lower_bound: u64::try_from(cut.len()).expect("test cut length must fit"),

--- a/crates/ledger-explorer/src/identity.rs
+++ b/crates/ledger-explorer/src/identity.rs
@@ -1,0 +1,335 @@
+//! Host-side execution-identity derivation.
+//!
+//! [`EngineBuild`] captures the engine build segment at compile time: source
+//! revision and dirty state, engine version, toolchain, target triple, build
+//! profile, enabled features, and the workspace lockfile digest. The capture
+//! is compile-time only; a mutable runtime environment variable is never the
+//! identity source.
+//!
+//! [`assemble_identity`] combines the build segment with the run context into
+//! the canonical [`ExecutionIdentity`] from `ledger-journal`.
+// ledger-lint:allow:env::var (host-side identity capture; the cross-process determinism test re-execs the test binary with a marker env var)
+// ledger-lint:allow:SystemTime::now (host-side identity capture; the cross-process test uniquifies the temp file name with the system clock)
+// ledger-lint:allow:std::fs:: (host-side identity capture; the cross-process test exchanges the digest through a temp file)
+
+use ledger_format::Hash;
+use ledger_journal::{
+    CRASH_SEMANTICS_VERSION, ExecutionIdentity, JOURNAL_FORMAT_VERSION, ResourceLimits,
+};
+
+/// Toolchain recorded when `LDGR_TOOLCHAIN` is not provided at build time.
+const FALLBACK_TOOLCHAIN: &str = "pinned-1.97";
+
+/// Target triple fallback when `build.rs` did not emit `LDGR_TARGET`.
+const FALLBACK_TARGET: &str = "unknown-unknown";
+
+/// Build-segment facts captured at compile time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EngineBuild {
+    /// ldgr source revision (`LDGR_ENGINE_SHA` at build time). `None` when
+    /// the revision was not provided, which makes identities incomplete.
+    pub revision: Option<String>,
+    /// Whether the ldgr source tree was dirty at build time.
+    pub dirty: bool,
+    /// Engine crate version (`CARGO_PKG_VERSION`).
+    pub version: String,
+    /// Toolchain identifier (`LDGR_TOOLCHAIN` at build time, else pinned).
+    pub toolchain: String,
+    /// Target triple emitted by `build.rs`.
+    pub target_triple: String,
+    /// Build profile (`debug` or `release`) emitted by `build.rs`.
+    pub build_profile: String,
+    /// Enabled engine features, comma separated and sorted.
+    pub features: String,
+    /// Digest of the workspace lockfile baked in at compile time.
+    pub lockfile_digest: Option<Hash>,
+}
+
+impl EngineBuild {
+    /// Capture the build segment of the binary that links this crate.
+    pub fn detect() -> Self {
+        Self {
+            revision: option_env!("LDGR_ENGINE_SHA").map(str::to_string),
+            dirty: option_env!("LDGR_DIRTY").is_some_and(|v| v == "1"),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            toolchain: option_env!("LDGR_TOOLCHAIN")
+                .unwrap_or(FALLBACK_TOOLCHAIN)
+                .to_string(),
+            target_triple: option_env!("LDGR_TARGET")
+                .unwrap_or(FALLBACK_TARGET)
+                .to_string(),
+            build_profile: option_env!("LDGR_BUILD_PROFILE")
+                .unwrap_or("unknown")
+                .to_string(),
+            features: feature_list(),
+            lockfile_digest: Some(lockfile_digest()),
+        }
+    }
+}
+
+/// Run-context facts filled by the caller for one specific execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityContext {
+    /// SUT repository revision; `None` when no SUT is bound.
+    pub sut_revision: Option<String>,
+    /// Whether the SUT tree was dirty at execution time.
+    pub sut_dirty: bool,
+    /// Digest of the SUT artifact when one is bound.
+    pub sut_artifact_digest: Option<Hash>,
+    /// Digest of a guest or component artifact when one is used.
+    pub guest_digest: Option<Hash>,
+    /// Workload identifier selecting the instruction programs.
+    pub workload_id: String,
+    /// Digest of the workload program set.
+    pub program_digest: Hash,
+    /// Digests of every workload input.
+    pub input_digests: Vec<Hash>,
+    /// Backend identifier (`sim`, `wasm`, `tokio`).
+    pub backend: String,
+    /// Runtime profile description or fingerprint of the executing host.
+    pub runtime_profile: String,
+    /// Digest of the canonical `RunConfig` bytes.
+    pub run_config_digest: Hash,
+    /// Root of the run's seed tree (the config root seed).
+    pub seed_tree_root: Hash,
+    /// Digest of the fault specification; `None` when no faults are bound.
+    pub faultspec_digest: Option<Hash>,
+    /// Oracle version; `None` when the default oracle is used.
+    pub oracle_version: Option<u64>,
+    /// Support-provider version; `None` when no provider is bound.
+    pub support_provider_version: Option<u64>,
+    /// Deterministic resource limits the run executes under.
+    pub resource_limits: ResourceLimits,
+}
+
+/// Combine the captured build segment with a run context into a full identity.
+pub fn assemble_identity(build: &EngineBuild, context: &IdentityContext) -> ExecutionIdentity {
+    ExecutionIdentity {
+        engine_revision: build.revision.clone(),
+        engine_dirty: build.dirty,
+        engine_version: build.version.clone(),
+        toolchain: build.toolchain.clone(),
+        target_triple: build.target_triple.clone(),
+        build_profile: build.build_profile.clone(),
+        features: build.features.clone(),
+        lockfile_digest: build.lockfile_digest,
+        sut_revision: context.sut_revision.clone(),
+        sut_dirty: context.sut_dirty,
+        sut_artifact_digest: context.sut_artifact_digest,
+        guest_digest: context.guest_digest,
+        workload_id: context.workload_id.clone(),
+        program_digest: context.program_digest,
+        input_digests: context.input_digests.clone(),
+        backend: context.backend.clone(),
+        runtime_profile: context.runtime_profile.clone(),
+        run_config_digest: context.run_config_digest,
+        seed_tree_root: context.seed_tree_root,
+        faultspec_digest: context.faultspec_digest,
+        oracle_version: context.oracle_version,
+        support_provider_version: context.support_provider_version,
+        journal_format_version: JOURNAL_FORMAT_VERSION,
+        crash_semantics_version: CRASH_SEMANTICS_VERSION,
+        resource_limits: context.resource_limits,
+    }
+}
+
+/// Comma-separated sorted list of enabled crate features.
+///
+/// The list feeds the identity digest, so an unlisted feature would make
+/// different builds claim the same identity.
+fn feature_list() -> String {
+    let mut features: Vec<&'static str> = Vec::new();
+    if cfg!(feature = "solver-cadical") {
+        features.push("solver-cadical");
+    }
+    features.sort_unstable();
+    features.join(",")
+}
+
+/// Digest of the workspace `Cargo.lock` baked in at compile time.
+///
+/// `include_str!` freezes the lockfile bytes into the binary and makes cargo
+/// rebuild when the lockfile changes, so the digest is a build-time constant
+/// without a build-dependency on blake3.
+fn lockfile_digest() -> Hash {
+    let lockfile = include_str!("../../../Cargo.lock");
+    *blake3::hash(lockfile.as_bytes()).as_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_build() -> EngineBuild {
+        EngineBuild {
+            revision: Some("rev-abc123".to_string()),
+            dirty: false,
+            version: "0.1.0".to_string(),
+            toolchain: "pinned-1.97".to_string(),
+            target_triple: "x86_64-unknown-linux-gnu".to_string(),
+            build_profile: "debug".to_string(),
+            features: "solver-cadical".to_string(),
+            lockfile_digest: Some([0x11; 32]),
+        }
+    }
+
+    fn sample_context() -> IdentityContext {
+        IdentityContext {
+            sut_revision: None,
+            sut_dirty: false,
+            sut_artifact_digest: None,
+            guest_digest: None,
+            workload_id: "kv".to_string(),
+            program_digest: [0x44; 32],
+            input_digests: Vec::new(),
+            backend: "sim".to_string(),
+            runtime_profile: "cpus=8".to_string(),
+            run_config_digest: [0x77; 32],
+            seed_tree_root: [0x88; 32],
+            faultspec_digest: None,
+            oracle_version: None,
+            support_provider_version: None,
+            resource_limits: ResourceLimits { max_steps: 10_000 },
+        }
+    }
+
+    #[test]
+    fn detect_captures_every_build_field() {
+        let build = EngineBuild::detect();
+        assert!(!build.version.is_empty());
+        assert!(!build.toolchain.is_empty());
+        assert!(!build.target_triple.is_empty());
+        assert!(build.lockfile_digest.is_some());
+        assert!(!build.features.is_empty() || cfg!(not(feature = "solver-cadical")));
+    }
+
+    #[test]
+    fn detect_is_stable_within_one_binary() {
+        let a = EngineBuild::detect();
+        let b = EngineBuild::detect();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn feature_list_is_sorted() {
+        let list = feature_list();
+        let parts: Vec<&str> = if list.is_empty() {
+            Vec::new()
+        } else {
+            list.split(',').collect()
+        };
+        let mut sorted = parts.clone();
+        sorted.sort_unstable();
+        assert_eq!(parts, sorted);
+    }
+
+    #[test]
+    fn assemble_maps_build_and_context_fields() {
+        let build = sample_build();
+        let context = sample_context();
+        let identity = assemble_identity(&build, &context);
+        assert_eq!(identity.engine_revision, build.revision);
+        assert_eq!(identity.backend, "sim");
+        assert_eq!(identity.journal_format_version, JOURNAL_FORMAT_VERSION);
+        assert_eq!(identity.crash_semantics_version, CRASH_SEMANTICS_VERSION);
+        assert!(identity.digest().is_some(), "sample identity is complete");
+    }
+
+    #[test]
+    fn identical_construction_across_processes() {
+        // Re-exec the current test binary as a child; the child writes the
+        // identity digest of the same build segment and context to a temp
+        // file, and the parent asserts byte equality. Deterministic
+        // construction must not depend on process-local state. The child
+        // communicates through a file because libtest captures test stdout.
+        const CHILD_ENV: &str = "LDGR_IDENTITY_CHILD";
+        const CHILD_OUT: &str = "LDGR_IDENTITY_CHILD_OUT";
+        let digest = |build: &EngineBuild, context: &IdentityContext| {
+            ledger_format::hash_to_hex(
+                &assemble_identity(build, context)
+                    .digest()
+                    .expect("complete identity"),
+            )
+        };
+        if std::env::var_os(CHILD_ENV).is_some() {
+            // Child mode: write the digest marker and exit before the harness
+            // runs the rest of the suite, so a child never re-execs itself.
+            let out = std::env::var_os(CHILD_OUT).expect("child out path is set");
+            std::fs::write(
+                &out,
+                format!("{}\n", digest(&sample_build(), &sample_context())),
+            )
+            .expect("child must write the digest");
+            std::process::exit(0);
+        }
+        let exe = std::env::current_exe().expect("test binary path is available");
+        let out_path = std::env::temp_dir().join(format!(
+            "ldgr-identity-child-{}-{}.digest",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after epoch")
+                .as_nanos()
+        ));
+        let child = std::process::Command::new(exe)
+            .env(CHILD_ENV, "1")
+            .env(CHILD_OUT, &out_path)
+            .arg("identity::tests::identical_construction_across_processes")
+            .output()
+            .expect("child must run");
+        assert!(
+            child.status.success(),
+            "child exited {:?}",
+            child.status.code()
+        );
+        let child_digest =
+            std::fs::read_to_string(&out_path).expect("child writes the digest marker");
+        let _ = std::fs::remove_file(&out_path);
+        assert_eq!(
+            child_digest.trim(),
+            digest(&sample_build(), &sample_context())
+        );
+    }
+
+    #[test]
+    fn dirty_tree_changes_the_digest() {
+        let build = sample_build();
+        let context = sample_context();
+        let clean = assemble_identity(&build, &context).digest();
+        let dirty = assemble_identity(
+            &EngineBuild {
+                dirty: true,
+                ..sample_build()
+            },
+            &context,
+        )
+        .digest();
+        assert_ne!(clean, dirty);
+    }
+
+    #[test]
+    fn feature_ordering_is_canonical() {
+        let build = sample_build();
+        let context = sample_context();
+        let a = assemble_identity(
+            &EngineBuild {
+                features: "a,b".to_string(),
+                ..build.clone()
+            },
+            &context,
+        )
+        .digest();
+        let b = assemble_identity(
+            &EngineBuild {
+                features: "b,a".to_string(),
+                ..build
+            },
+            &context,
+        )
+        .digest();
+        assert_ne!(
+            a, b,
+            "features are bound as given; callers sort before capture"
+        );
+    }
+}

--- a/crates/ledger-explorer/src/lib.rs
+++ b/crates/ledger-explorer/src/lib.rs
@@ -9,6 +9,7 @@ pub mod coverage;
 mod diagnosis;
 pub mod faultspec_bridge;
 pub mod forensics;
+pub mod identity;
 pub mod ldfi;
 pub mod lineage;
 pub mod maxsat;

--- a/crates/ledger-explorer/src/services.rs
+++ b/crates/ledger-explorer/src/services.rs
@@ -138,12 +138,14 @@ pub fn emit_statement(
     builder_id: &str,
     dependencies: Vec<ResolvedDependency>,
     run_config_digest: Hash,
+    execution_identity: Option<Hash>,
 ) -> Result<CampaignCertificate, ServiceError> {
     Ok(CampaignCertificate::from_campaign(
         report,
         builder_id,
         dependencies,
         run_config_digest,
+        execution_identity,
     )?)
 }
 

--- a/crates/ledger-explorer/tests/capability_gates.rs
+++ b/crates/ledger-explorer/tests/capability_gates.rs
@@ -448,6 +448,7 @@ fn run_scaling_chain(n: usize) -> (usize, usize, usize, usize, bool, bool, Durat
         "capability-gate-builder",
         Vec::new(),
         [9u8; 32],
+        None,
     )
     .expect("certificate emission must succeed");
     let verified = cert

--- a/crates/ledger-explorer/tests/certificate_emission.rs
+++ b/crates/ledger-explorer/tests/certificate_emission.rs
@@ -27,7 +27,7 @@ fn certificate_write_and_verify_roundtrip() {
     let builder = "test-builder-certificate-emission";
     let path = temp_cert_path("roundtrip");
     report
-        .write_certificate(&path, digest, builder)
+        .write_certificate(&path, digest, builder, None)
         .expect("write_certificate must succeed");
     let json = std::fs::read_to_string(&path).expect("certificate file must be readable");
     assert!(
@@ -65,12 +65,22 @@ fn from_campaign_is_deterministic() {
     .unwrap();
     let digest = [7u8; 32];
     let builder = "helper-builder";
-    let cert_a =
-        ledger_explorer::CampaignCertificate::from_campaign(&report, builder, Vec::new(), digest)
-            .unwrap();
-    let cert_b =
-        ledger_explorer::CampaignCertificate::from_campaign(&report, builder, Vec::new(), digest)
-            .unwrap();
+    let cert_a = ledger_explorer::CampaignCertificate::from_campaign(
+        &report,
+        builder,
+        Vec::new(),
+        digest,
+        None,
+    )
+    .unwrap();
+    let cert_b = ledger_explorer::CampaignCertificate::from_campaign(
+        &report,
+        builder,
+        Vec::new(),
+        digest,
+        None,
+    )
+    .unwrap();
     assert_eq!(cert_a.builder_id, cert_b.builder_id);
     assert_eq!(
         cert_a.external_parameters_digest,
@@ -113,6 +123,7 @@ fn recorded_solver_data_from_real_cut_verifies() {
         "test-builder-solver-data",
         Vec::new(),
         [2u8; 32],
+        None,
     )
     .unwrap();
     certificate.solver_data = Some(extension.clone());

--- a/crates/ledger-explorer/tests/corpus_v2_gate.rs
+++ b/crates/ledger-explorer/tests/corpus_v2_gate.rs
@@ -261,6 +261,7 @@ fn ldfi_finds_every_v2_bug_with_valid_minimal_certificate() {
             "corpus-v2-ldfi",
             Vec::new(),
             [9u8; 32],
+            None,
         )
         .unwrap();
         cert_for_verify.solver_data = Some(cert.clone());

--- a/crates/ledger-explorer/tests/services.rs
+++ b/crates/ledger-explorer/tests/services.rs
@@ -217,8 +217,8 @@ fn minimize_decisions_reduces_a_monotone_predicate() {
 fn emit_parse_validate_round_trip() {
     let report: CampaignReport =
         run_campaign(&OutcomeWorkload(99), &final_is(7), config(7), 1).expect("campaign must run");
-    let certificate =
-        emit_statement(&report, "builder", Vec::new(), [1u8; 32]).expect("statement must emit");
+    let certificate = emit_statement(&report, "builder", Vec::new(), [1u8; 32], None)
+        .expect("statement must emit");
     let json = certificate.to_json().expect("serialize");
     let parsed = parse_statement(&json).expect("statement must parse");
     validate_statement(&parsed).expect("statement must validate");
@@ -242,7 +242,7 @@ fn emit_parse_validate_round_trip() {
         })
         .collect();
     let lineage_only = CampaignReport { findings, ..report };
-    let err = emit_statement(&lineage_only, "builder", Vec::new(), [1u8; 32])
+    let err = emit_statement(&lineage_only, "builder", Vec::new(), [1u8; 32], None)
         .expect_err("lineage-only journals must be rejected");
     assert!(
         matches!(err, ServiceError::Cert(CertError::Verification(_))),
@@ -260,8 +260,8 @@ fn emit_parse_validate_round_trip() {
 fn validate_cut_against_journal_rejects_zero_digest_binding() {
     let report: CampaignReport =
         run_campaign(&OutcomeWorkload(99), &final_is(99), config(8), 1).expect("campaign must run");
-    let mut certificate =
-        emit_statement(&report, "builder", Vec::new(), [1u8; 32]).expect("statement must emit");
+    let mut certificate = emit_statement(&report, "builder", Vec::new(), [1u8; 32], None)
+        .expect("statement must emit");
     // A zero subject digest never binds to any journal in journal mode.
     certificate.subject.digest = [0u8; 32];
     let journal = Journal::new();

--- a/crates/ledger-format/src/manifest.rs
+++ b/crates/ledger-format/src/manifest.rs
@@ -2,11 +2,21 @@
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
+use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::cbor::{self, CborError, CborValue};
 use crate::entry::{ActorId, Hash};
+
+/// Extension-map key carrying the execution-identity digest in the manifest.
+///
+/// The digest is a 32-byte BLAKE3 hash of the canonical
+/// `ledger_journal::identity::ExecutionIdentity` bytes. `ledger-format`
+/// cannot depend on `ledger-journal`, so the key is a documented string
+/// constant rather than a typed re-export; both sides agree on the key name
+/// and the 32-byte payload shape.
+const EXECUTION_IDENTITY_EXTENSION: &str = "execution_identity";
 
 /// Current manifest format version. Version 1 is the only supported version.
 pub const MANIFEST_FORMAT_VERSION: u32 = 1;
@@ -47,6 +57,13 @@ pub struct RunManifest {
     pub actor_heads: BTreeMap<ActorId, Hash>,
     /// Reserved extension fields for append-only format evolution.
     pub extensions: BTreeMap<String, CborValue>,
+    /// Execution-identity digest of the run that produced this manifest.
+    ///
+    /// Encoded inside [`Self::extensions`] under `execution_identity`, so the
+    /// canonical wire form (array of 7 items) is unchanged. `None` means the
+    /// run did not bind an identity; a root comparison involving this
+    /// manifest must treat the identity as incomplete.
+    pub execution_identity: Option<Hash>,
 }
 
 impl RunManifest {
@@ -118,8 +135,14 @@ impl RunManifest {
             .collect();
         CborValue::Map(heads).try_encode(&mut out)?;
 
-        let extensions: Vec<(CborValue, CborValue)> = self
-            .extensions
+        let mut extensions = self.extensions.clone();
+        if let Some(identity) = &self.execution_identity {
+            extensions.insert(
+                EXECUTION_IDENTITY_EXTENSION.to_string(),
+                CborValue::Bytes(identity.to_vec()),
+            );
+        }
+        let extensions: Vec<(CborValue, CborValue)> = extensions
             .iter()
             .map(|(key, val)| (CborValue::Text(key.clone()), val.clone()))
             .collect();
@@ -238,6 +261,22 @@ impl RunManifest {
             _ => return Err(CborError::MalformedManifest("extensions must be a map")),
         };
 
+        let execution_identity = match extensions.get(EXECUTION_IDENTITY_EXTENSION) {
+            Some(CborValue::Bytes(b)) => {
+                Some(<[u8; 32]>::try_from(b.as_slice()).map_err(|_| {
+                    CborError::MalformedManifest(
+                        "execution_identity extension must be a 32-byte hash",
+                    )
+                })?)
+            }
+            Some(_) => {
+                return Err(CborError::MalformedManifest(
+                    "execution_identity extension must be a byte string",
+                ));
+            }
+            None => None,
+        };
+
         Ok(RunManifest {
             format_version,
             root_seed,
@@ -246,6 +285,80 @@ impl RunManifest {
             entry_count,
             actor_heads,
             extensions,
+            execution_identity,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    fn sample_manifest() -> RunManifest {
+        RunManifest {
+            format_version: MANIFEST_FORMAT_VERSION,
+            root_seed: [0x01; 32],
+            policy_tag: "random".to_string(),
+            journal_root: [0x02; 32],
+            entry_count: 7,
+            actor_heads: BTreeMap::new(),
+            extensions: BTreeMap::new(),
+            execution_identity: None,
+        }
+    }
+
+    #[test]
+    fn identity_extension_round_trips() {
+        let mut manifest = sample_manifest();
+        manifest.execution_identity = Some([0xab; 32]);
+        let bytes = manifest.to_canonical_bytes().expect("manifest encodes");
+        let decoded = RunManifest::from_canonical_bytes(&bytes).expect("manifest decodes");
+        assert_eq!(decoded.execution_identity, Some([0xab; 32]));
+        assert_eq!(decoded.to_canonical_bytes().expect("re-encode"), bytes);
+    }
+
+    #[test]
+    fn identity_absent_stays_absent() {
+        // A legacy manifest without the extension key decodes with no
+        // identity; root comparison treats that as incomplete.
+        let manifest = sample_manifest();
+        let bytes = manifest.to_canonical_bytes().expect("manifest encodes");
+        let decoded = RunManifest::from_canonical_bytes(&bytes).expect("manifest decodes");
+        assert_eq!(decoded.execution_identity, None);
+    }
+
+    #[test]
+    fn identity_presence_changes_canonical_bytes() {
+        let plain = sample_manifest();
+        let mut bound = sample_manifest();
+        bound.execution_identity = Some([0xab; 32]);
+        assert_ne!(
+            plain.to_canonical_bytes().expect("plain encodes"),
+            bound.to_canonical_bytes().expect("bound encodes")
+        );
+    }
+
+    #[test]
+    fn identity_extension_rejects_wrong_shape() {
+        let mut manifest = sample_manifest();
+        manifest.extensions.insert(
+            EXECUTION_IDENTITY_EXTENSION.to_string(),
+            CborValue::Bytes(vec![1, 2, 3]),
+        );
+        let bytes = manifest.to_canonical_bytes().expect("manifest encodes");
+        let error = RunManifest::from_canonical_bytes(&bytes)
+            .expect_err("wrong-length identity must be rejected");
+        assert!(matches!(error, CborError::MalformedManifest(_)));
+
+        let mut manifest = sample_manifest();
+        manifest.extensions.insert(
+            EXECUTION_IDENTITY_EXTENSION.to_string(),
+            CborValue::Unsigned(7),
+        );
+        let bytes = manifest.to_canonical_bytes().expect("manifest encodes");
+        let error = RunManifest::from_canonical_bytes(&bytes)
+            .expect_err("non-byte identity must be rejected");
+        assert!(matches!(error, CborError::MalformedManifest(_)));
     }
 }

--- a/crates/ledger-format/tests/cbor_conformance.rs
+++ b/crates/ledger-format/tests/cbor_conformance.rs
@@ -583,6 +583,7 @@ fn manifest_round_trip_and_version_reject() {
         journal_root: [9u8; 32],
         entry_count: 1234,
         actor_heads: BTreeMap::from([(1u32, [1u8; 32]), (2u32, [2u8; 32])]),
+        execution_identity: None,
         extensions: BTreeMap::new(),
     };
 

--- a/crates/ledger-format/tests/conformance.rs
+++ b/crates/ledger-format/tests/conformance.rs
@@ -579,6 +579,7 @@ fn sample_manifest_bytes() -> Vec<u8> {
         journal_root: [9u8; 32],
         entry_count: 42,
         actor_heads: BTreeMap::from([(0u32, [1u8; 32]), (1u32, [2u8; 32])]),
+        execution_identity: None,
         extensions: BTreeMap::from([("probe".into(), CborValue::Unsigned(1))]),
     }
     .to_canonical_bytes()
@@ -760,6 +761,7 @@ fn manifest_version_migration() {
         journal_root: [9u8; 32],
         entry_count: 1234,
         actor_heads: BTreeMap::from([(1u32, [1u8; 32]), (2u32, [2u8; 32])]),
+        execution_identity: None,
         extensions: BTreeMap::from([("probe".into(), CborValue::Unsigned(99))]),
     };
     assert!(ManifestVersion::CURRENT.is_supported());

--- a/crates/ledger-format/tests/fuzz_mutation.rs
+++ b/crates/ledger-format/tests/fuzz_mutation.rs
@@ -103,6 +103,7 @@ fn seed_corpus() -> Vec<Vec<u8>> {
         journal_root: [9u8; 32],
         entry_count: 42,
         actor_heads: BTreeMap::from([(0u32, [1u8; 32]), (1u32, [2u8; 32])]),
+        execution_identity: None,
         extensions: BTreeMap::from([("probe".into(), CborValue::Unsigned(1))]),
     };
     corpus.push(
@@ -242,6 +243,7 @@ fn mutation_harness_never_panics() {
         journal_root: [9u8; 32],
         entry_count: 42,
         actor_heads: BTreeMap::from([(0u32, [1u8; 32]), (1u32, [2u8; 32])]),
+        execution_identity: None,
         extensions: BTreeMap::from([("probe".into(), CborValue::Unsigned(1))]),
     };
     let manifest_bytes = manifest

--- a/crates/ledger-journal/src/identity.rs
+++ b/crates/ledger-journal/src/identity.rs
@@ -1,0 +1,544 @@
+//! Execution identity: the canonical run and build binding.
+//!
+//! An [`ExecutionIdentity`] binds every fact that must match for two runs to
+//! be comparable: the engine build (source revision, dirty state, version,
+//! toolchain, target triple, build profile, enabled features, and lockfile
+//! digest), the SUT and guest artifacts, the workload and its inputs, the
+//! backend and runtime profile, the canonical `RunConfig` digest and seed-tree
+//! root, the fault specification, the oracle and support-provider versions,
+//! the journal format and crash-semantics versions, and the deterministic
+//! resource limits.
+//!
+//! The canonical byte form is length-prefixed field encoding in declaration
+//! order. The digest is a BLAKE3 keyed hash over those bytes with a fixed
+//! domain key, so identity digests are domain-separated from every other hash
+//! in the system. An identity missing required build data is incomplete and
+//! has no digest: [`Self::digest`] returns `None`, and a root comparison must
+//! fail before comparing roots when either side is incomplete.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use ledger_format::Hash;
+
+/// Domain key for execution-identity digests. Exactly 32 bytes; changing the
+/// key changes every identity digest and is a breaking format change.
+const IDENTITY_DOMAIN_KEY: [u8; 32] = *b"ldgr.execution-identity.v1\0\0\0\0\0\0";
+
+/// Journal format version bound by every identity. Bumped only by an approved
+/// format change (E2 owns format v2).
+pub const JOURNAL_FORMAT_VERSION: u32 = 1;
+
+/// Crash-semantics version bound by every identity. Bumped only by an approved
+/// crash-semantics change (E2 owns versioned fail-closed recovery).
+pub const CRASH_SEMANTICS_VERSION: u32 = 1;
+
+/// Deterministic resource limits bound by an execution identity.
+///
+/// The identity binds the limits so a run executed under different budgets is
+/// never compared as if it were the same run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ResourceLimits {
+    /// Maximum scheduler steps granted to the run.
+    pub max_steps: u64,
+}
+
+/// Canonical build and run binding for one execution.
+///
+/// Fields in the build segment come from compile-time capture (see
+/// `ledger_explorer::identity::EngineBuild`); fields in the run segment come
+/// from the configuration and context of the specific run. An identity is
+/// complete when every required build field is present; see
+/// [`Self::is_complete`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionIdentity {
+    // Build segment (compile-time derived).
+    /// ldgr source revision; `None` means build data was missing at compile
+    /// time, which makes the identity incomplete.
+    pub engine_revision: Option<String>,
+    /// Whether the ldgr source tree was dirty at build time.
+    pub engine_dirty: bool,
+    /// Engine crate version baked at compile time.
+    pub engine_version: String,
+    /// Toolchain identifier baked at compile time.
+    pub toolchain: String,
+    /// Target triple baked at compile time.
+    pub target_triple: String,
+    /// Build profile (`debug` or `release`) baked at compile time.
+    pub build_profile: String,
+    /// Enabled engine features, comma separated and sorted.
+    pub features: String,
+    /// Digest of the workspace lockfile baked at compile time.
+    pub lockfile_digest: Option<Hash>,
+    // Run segment (runtime derived).
+    /// SUT repository revision; `None` when no SUT is bound.
+    pub sut_revision: Option<String>,
+    /// Whether the SUT tree was dirty at execution time.
+    pub sut_dirty: bool,
+    /// Digest of the SUT artifact when one is bound.
+    pub sut_artifact_digest: Option<Hash>,
+    /// Digest of a guest or component artifact when one is used.
+    pub guest_digest: Option<Hash>,
+    /// Workload identifier selecting the instruction programs.
+    pub workload_id: String,
+    /// Digest of the workload program set.
+    pub program_digest: Hash,
+    /// Digests of every workload input, order independent.
+    pub input_digests: Vec<Hash>,
+    /// Backend identifier (`sim`, `wasm`, `tokio`).
+    pub backend: String,
+    /// Runtime profile description or fingerprint of the executing host.
+    pub runtime_profile: String,
+    /// Digest of the canonical `RunConfig` bytes.
+    pub run_config_digest: Hash,
+    /// Root of the run's seed tree (the config root seed).
+    pub seed_tree_root: Hash,
+    /// Digest of the fault specification; `None` when no faults are bound.
+    pub faultspec_digest: Option<Hash>,
+    /// Oracle version; `None` when the default oracle is used.
+    pub oracle_version: Option<u64>,
+    /// Support-provider version; `None` when no provider is bound.
+    pub support_provider_version: Option<u64>,
+    /// Journal format version at execution time.
+    pub journal_format_version: u32,
+    /// Crash-semantics version at execution time.
+    pub crash_semantics_version: u32,
+    /// Deterministic resource limits the run executed under.
+    pub resource_limits: ResourceLimits,
+}
+
+impl ExecutionIdentity {
+    /// Whether every required build field is present.
+    ///
+    /// An identity with missing build data (no source revision, no lockfile
+    /// digest, or an empty version, toolchain, target, or profile) is
+    /// incomplete: it cannot be compared against another identity, and
+    /// [`Self::digest`] returns `None`.
+    pub fn is_complete(&self) -> bool {
+        self.engine_revision.is_some()
+            && self.lockfile_digest.is_some()
+            && !self.engine_version.is_empty()
+            && !self.toolchain.is_empty()
+            && !self.target_triple.is_empty()
+            && !self.build_profile.is_empty()
+    }
+
+    /// Canonical length-prefixed field encoding in declaration order.
+    ///
+    /// `input_digests` is sorted before encoding so insertion order never
+    /// changes the bytes. The encoding is total: an incomplete identity still
+    /// encodes, it just has no comparable digest.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        encode_opt_str(&self.engine_revision, &mut out);
+        encode_bool(self.engine_dirty, &mut out);
+        encode_str(&self.engine_version, &mut out);
+        encode_str(&self.toolchain, &mut out);
+        encode_str(&self.target_triple, &mut out);
+        encode_str(&self.build_profile, &mut out);
+        encode_str(&self.features, &mut out);
+        encode_opt_hash(&self.lockfile_digest, &mut out);
+        encode_opt_str(&self.sut_revision, &mut out);
+        encode_bool(self.sut_dirty, &mut out);
+        encode_opt_hash(&self.sut_artifact_digest, &mut out);
+        encode_opt_hash(&self.guest_digest, &mut out);
+        encode_str(&self.workload_id, &mut out);
+        encode_hash(&self.program_digest, &mut out);
+        encode_hashes(&self.input_digests, &mut out);
+        encode_str(&self.backend, &mut out);
+        encode_str(&self.runtime_profile, &mut out);
+        encode_hash(&self.run_config_digest, &mut out);
+        encode_hash(&self.seed_tree_root, &mut out);
+        encode_opt_hash(&self.faultspec_digest, &mut out);
+        encode_opt_u64(self.oracle_version, &mut out);
+        encode_opt_u64(self.support_provider_version, &mut out);
+        encode_u32(self.journal_format_version, &mut out);
+        encode_u32(self.crash_semantics_version, &mut out);
+        encode_u64(self.resource_limits.max_steps, &mut out);
+        out
+    }
+
+    /// Domain-separated BLAKE3 digest of the canonical identity bytes.
+    ///
+    /// Returns `None` when the identity is incomplete. Callers must treat a
+    /// `None` as an identity disagreement before any root comparison.
+    pub fn digest(&self) -> Option<Hash> {
+        if !self.is_complete() {
+            return None;
+        }
+        Some(*blake3::keyed_hash(&IDENTITY_DOMAIN_KEY, &self.canonical_bytes()).as_bytes())
+    }
+}
+
+fn encode_bool(value: bool, out: &mut Vec<u8>) {
+    out.push(u8::from(value));
+}
+
+fn encode_u32(value: u32, out: &mut Vec<u8>) {
+    out.extend_from_slice(&u64::from(value).to_le_bytes());
+}
+
+fn encode_u64(value: u64, out: &mut Vec<u8>) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn encode_opt_u64(value: Option<u64>, out: &mut Vec<u8>) {
+    match value {
+        Some(v) => {
+            out.push(1);
+            encode_u64(v, out);
+        }
+        None => out.push(0),
+    }
+}
+
+fn encode_str(value: &str, out: &mut Vec<u8>) {
+    out.extend_from_slice(&(value.len() as u64).to_le_bytes());
+    out.extend_from_slice(value.as_bytes());
+}
+
+fn encode_opt_str(value: &Option<String>, out: &mut Vec<u8>) {
+    match value {
+        Some(s) => {
+            out.push(1);
+            encode_str(s, out);
+        }
+        None => out.push(0),
+    }
+}
+
+fn encode_hash(value: &Hash, out: &mut Vec<u8>) {
+    out.extend_from_slice(value);
+}
+
+fn encode_opt_hash(value: &Option<Hash>, out: &mut Vec<u8>) {
+    match value {
+        Some(h) => {
+            out.push(1);
+            encode_hash(h, out);
+        }
+        None => out.push(0),
+    }
+}
+
+fn encode_hashes(values: &[Hash], out: &mut Vec<u8>) {
+    let mut sorted: Vec<Hash> = values.to_vec();
+    sorted.sort_unstable();
+    out.extend_from_slice(&(sorted.len() as u64).to_le_bytes());
+    for hash in &sorted {
+        encode_hash(hash, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+    use alloc::vec;
+
+    /// A complete identity with distinct values in every field.
+    fn sample() -> ExecutionIdentity {
+        ExecutionIdentity {
+            engine_revision: Some("rev-abc123".to_string()),
+            engine_dirty: false,
+            engine_version: "0.1.0".to_string(),
+            toolchain: "1.97.1-x86_64-unknown-linux-gnu".to_string(),
+            target_triple: "x86_64-unknown-linux-gnu".to_string(),
+            build_profile: "debug".to_string(),
+            features: "default,solver-cadical".to_string(),
+            lockfile_digest: Some([0x11; 32]),
+            sut_revision: Some("sut-rev-9".to_string()),
+            sut_dirty: false,
+            sut_artifact_digest: Some([0x22; 32]),
+            guest_digest: Some([0x33; 32]),
+            workload_id: "kv".to_string(),
+            program_digest: [0x44; 32],
+            input_digests: vec![[0x55; 32], [0x66; 32]],
+            backend: "sim".to_string(),
+            runtime_profile: "cpus=8".to_string(),
+            run_config_digest: [0x77; 32],
+            seed_tree_root: [0x88; 32],
+            faultspec_digest: Some([0x99; 32]),
+            oracle_version: Some(1),
+            support_provider_version: Some(2),
+            journal_format_version: JOURNAL_FORMAT_VERSION,
+            crash_semantics_version: CRASH_SEMANTICS_VERSION,
+            resource_limits: ResourceLimits { max_steps: 10_000 },
+        }
+    }
+
+    #[test]
+    fn digest_is_deterministic() {
+        let identity = sample();
+        assert_eq!(identity.digest(), identity.digest());
+    }
+
+    #[test]
+    fn canonical_bytes_are_deterministic() {
+        assert_eq!(sample().canonical_bytes(), sample().canonical_bytes());
+    }
+
+    #[test]
+    fn digest_changes_when_any_field_changes() {
+        let base = sample();
+        let base_digest = base.digest().expect("sample identity is complete");
+        let mutations: Vec<(&str, ExecutionIdentity)> = vec![
+            (
+                "engine_revision",
+                ExecutionIdentity {
+                    engine_revision: Some("rev-other".to_string()),
+                    ..base.clone()
+                },
+            ),
+            (
+                "engine_dirty",
+                ExecutionIdentity {
+                    engine_dirty: true,
+                    ..base.clone()
+                },
+            ),
+            (
+                "engine_version",
+                ExecutionIdentity {
+                    engine_version: "0.2.0".to_string(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "toolchain",
+                ExecutionIdentity {
+                    toolchain: "1.98.0".to_string(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "target_triple",
+                ExecutionIdentity {
+                    target_triple: "aarch64-unknown-linux-gnu".to_string(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "build_profile",
+                ExecutionIdentity {
+                    build_profile: "release".to_string(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "features",
+                ExecutionIdentity {
+                    features: "solver-cadical".to_string(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "lockfile_digest",
+                ExecutionIdentity {
+                    lockfile_digest: Some([0x12; 32]),
+                    ..base.clone()
+                },
+            ),
+            (
+                "sut_revision",
+                ExecutionIdentity {
+                    sut_revision: Some("sut-rev-other".to_string()),
+                    ..base.clone()
+                },
+            ),
+            (
+                "sut_dirty",
+                ExecutionIdentity {
+                    sut_dirty: true,
+                    ..base.clone()
+                },
+            ),
+            (
+                "sut_artifact_digest",
+                ExecutionIdentity {
+                    sut_artifact_digest: Some([0x23; 32]),
+                    ..base.clone()
+                },
+            ),
+            (
+                "guest_digest",
+                ExecutionIdentity {
+                    guest_digest: Some([0x34; 32]),
+                    ..base.clone()
+                },
+            ),
+            (
+                "workload_id",
+                ExecutionIdentity {
+                    workload_id: "linearizable-register".to_string(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "program_digest",
+                ExecutionIdentity {
+                    program_digest: [0x45; 32],
+                    ..base.clone()
+                },
+            ),
+            (
+                "input_digests",
+                ExecutionIdentity {
+                    input_digests: vec![[0x55; 32]],
+                    ..base.clone()
+                },
+            ),
+            (
+                "backend",
+                ExecutionIdentity {
+                    backend: "wasm".to_string(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "runtime_profile",
+                ExecutionIdentity {
+                    runtime_profile: "cpus=16".to_string(),
+                    ..base.clone()
+                },
+            ),
+            (
+                "run_config_digest",
+                ExecutionIdentity {
+                    run_config_digest: [0x78; 32],
+                    ..base.clone()
+                },
+            ),
+            (
+                "seed_tree_root",
+                ExecutionIdentity {
+                    seed_tree_root: [0x89; 32],
+                    ..base.clone()
+                },
+            ),
+            (
+                "faultspec_digest",
+                ExecutionIdentity {
+                    faultspec_digest: Some([0x9a; 32]),
+                    ..base.clone()
+                },
+            ),
+            (
+                "oracle_version",
+                ExecutionIdentity {
+                    oracle_version: Some(3),
+                    ..base.clone()
+                },
+            ),
+            (
+                "support_provider_version",
+                ExecutionIdentity {
+                    support_provider_version: Some(4),
+                    ..base.clone()
+                },
+            ),
+            (
+                "journal_format_version",
+                ExecutionIdentity {
+                    journal_format_version: 2,
+                    ..base.clone()
+                },
+            ),
+            (
+                "crash_semantics_version",
+                ExecutionIdentity {
+                    crash_semantics_version: 2,
+                    ..base.clone()
+                },
+            ),
+            (
+                "resource_limits",
+                ExecutionIdentity {
+                    resource_limits: ResourceLimits { max_steps: 20_000 },
+                    ..base.clone()
+                },
+            ),
+        ];
+        for (name, mutation) in &mutations {
+            let digest = mutation.digest().expect("mutated identity stays complete");
+            assert_ne!(digest, base_digest, "{name} must change the digest");
+        }
+    }
+
+    #[test]
+    fn input_digest_order_does_not_change_digest() {
+        let a = sample();
+        let mut b = sample();
+        b.input_digests.reverse();
+        assert_eq!(a.canonical_bytes(), b.canonical_bytes());
+        assert_eq!(a.digest(), b.digest());
+    }
+
+    #[test]
+    fn missing_revision_makes_identity_incomplete() {
+        let identity = ExecutionIdentity {
+            engine_revision: None,
+            ..sample()
+        };
+        assert!(!identity.is_complete());
+        assert_eq!(identity.digest(), None);
+    }
+
+    #[test]
+    fn missing_lockfile_makes_identity_incomplete() {
+        let identity = ExecutionIdentity {
+            lockfile_digest: None,
+            ..sample()
+        };
+        assert!(!identity.is_complete());
+        assert_eq!(identity.digest(), None);
+    }
+
+    #[test]
+    fn empty_build_fields_make_identity_incomplete() {
+        for field in [
+            "engine_version",
+            "toolchain",
+            "target_triple",
+            "build_profile",
+        ] {
+            let mut identity = sample();
+            match field {
+                "engine_version" => identity.engine_version = String::new(),
+                "toolchain" => identity.toolchain = String::new(),
+                "target_triple" => identity.target_triple = String::new(),
+                "build_profile" => identity.build_profile = String::new(),
+                _ => unreachable!(),
+            }
+            assert!(!identity.is_complete(), "{field} empty must be incomplete");
+            assert_eq!(
+                identity.digest(),
+                None,
+                "{field} empty must yield no digest"
+            );
+        }
+    }
+
+    #[test]
+    fn run_segment_options_do_not_affect_completeness() {
+        let identity = ExecutionIdentity {
+            sut_revision: None,
+            sut_artifact_digest: None,
+            guest_digest: None,
+            faultspec_digest: None,
+            oracle_version: None,
+            support_provider_version: None,
+            ..sample()
+        };
+        assert!(identity.is_complete());
+        assert!(identity.digest().is_some());
+    }
+
+    #[test]
+    fn digest_is_domain_separated_from_plain_blake3() {
+        let identity = sample();
+        let digest = identity.digest().expect("sample identity is complete");
+        let plain = blake3::hash(&identity.canonical_bytes());
+        assert_ne!(&digest, plain.as_bytes());
+    }
+}

--- a/crates/ledger-journal/src/lib.rs
+++ b/crates/ledger-journal/src/lib.rs
@@ -19,6 +19,7 @@ extern crate std;
 pub mod archive;
 pub mod clock;
 pub mod dag;
+pub mod identity;
 pub mod monitor;
 #[cfg(feature = "std")]
 pub mod persistent;
@@ -32,6 +33,9 @@ pub mod snapshot_store;
 
 pub use clock::VectorClock;
 pub use dag::{BatchEntry, Entry, EntryFrame, Journal, JournalError};
+pub use identity::{
+    CRASH_SEMANTICS_VERSION, ExecutionIdentity, JOURNAL_FORMAT_VERSION, ResourceLimits,
+};
 pub use monitor::{JournalCorrectnessMonitor, MonitorIssue, VerificationReport};
 #[cfg(feature = "std")]
 pub use persistent::PersistentJournal;

--- a/crates/ledger-worker/src/queue/mod.rs
+++ b/crates/ledger-worker/src/queue/mod.rs
@@ -56,6 +56,13 @@ pub struct Task {
     pub workload: String,
     /// Optional deterministic hash of run_config, computed at queue push.
     pub run_config_hash: Option<Hash>,
+    /// Execution-identity digest pinned by the task author.
+    ///
+    /// When present, the worker recomputes its own identity for the task
+    /// and rejects the task before execution when the digests differ or its
+    /// own identity is incomplete. `None` leaves the worker to record its
+    /// own assembled identity in the result.
+    pub execution_identity: Option<Hash>,
     /// Execution attempts charged against this task.
     pub attempts: u32,
     /// Attempt budget; exhaustion moves the task to the failed list.
@@ -73,6 +80,7 @@ impl Task {
             run_config,
             workload: workload.into(),
             run_config_hash: None,
+            execution_identity: None,
             attempts: 0,
             max_attempts: DEFAULT_MAX_ATTEMPTS,
             status: TaskStatus::Queued,

--- a/crates/ledger-worker/src/worker.rs
+++ b/crates/ledger-worker/src/worker.rs
@@ -22,6 +22,12 @@ pub struct WorkerResult {
     pub steps: usize,
     /// Findings count from the pre-run explorer campaign.
     pub campaign_findings: usize,
+    /// Execution-identity digest assembled by the worker for this task.
+    ///
+    /// `None` when the worker build data is incomplete (no source revision
+    /// captured at compile time); such results must be treated as
+    /// identity-incomplete by the control plane.
+    pub execution_identity: Option<Hash>,
 }
 
 /// Errors from worker execution.
@@ -31,6 +37,22 @@ pub enum WorkerError {
     /// hash; the deterministic boundary rejects the task.
     #[error("run_config_hash mismatch for task {task_id}")]
     HashMismatch {
+        /// Identifier of the rejected task.
+        task_id: String,
+    },
+    /// The task pinned an execution-identity digest that differs from the
+    /// identity the worker assembled for it; the run is rejected before
+    /// execution.
+    #[error("execution identity mismatch for task {task_id}")]
+    IdentityMismatch {
+        /// Identifier of the rejected task.
+        task_id: String,
+    },
+    /// The task pinned an execution-identity digest but the worker build
+    /// data is incomplete, so no comparable identity exists; the run is
+    /// rejected before execution.
+    #[error("execution identity incomplete for task {task_id}")]
+    IdentityIncomplete {
         /// Identifier of the rejected task.
         task_id: String,
     },
@@ -286,6 +308,22 @@ pub fn execute_task(task: crate::queue::Task) -> Result<WorkerResult, WorkerErro
             task_id: task.id.clone(),
         });
     }
+    // Identity gate runs before the simulation: a pinned identity that does
+    // not match the worker's own assembly (or that cannot be compared because
+    // the worker build data is incomplete) rejects the task.
+    let execution_identity = task_identity(&task, computed)?;
+    if let Some(pin) = task.execution_identity {
+        let Some(assembled) = execution_identity else {
+            return Err(WorkerError::IdentityIncomplete {
+                task_id: task.id.clone(),
+            });
+        };
+        if assembled != pin {
+            return Err(WorkerError::IdentityMismatch {
+                task_id: task.id.clone(),
+            });
+        }
+    }
     let workload = workload_for(&task.workload);
     let oracle = AlwaysPassOracle;
     let campaign =
@@ -297,7 +335,43 @@ pub fn execute_task(task: crate::queue::Task) -> Result<WorkerResult, WorkerErro
         journal_root: run.journal.root_hash(),
         steps: run.steps,
         campaign_findings,
+        execution_identity,
     })
+}
+
+/// Assemble the worker's execution-identity digest for one task.
+///
+/// The build segment comes from the worker binary's compile-time capture; the
+/// run segment comes from the task's run config and workload selector. Returns
+/// `None` when the worker build data is incomplete.
+fn task_identity(
+    task: &crate::queue::Task,
+    run_config_digest: Hash,
+) -> Result<Option<Hash>, WorkerError> {
+    use ledger_explorer::identity::{EngineBuild, IdentityContext};
+    let build = EngineBuild::detect();
+    let context = IdentityContext {
+        sut_revision: None,
+        sut_dirty: false,
+        sut_artifact_digest: None,
+        guest_digest: None,
+        workload_id: task.workload.clone(),
+        // The program selector binds which program set was chosen; the
+        // workload provider owns the program-by-program binding.
+        program_digest: *blake3::hash(task.workload.as_bytes()).as_bytes(),
+        input_digests: Vec::new(),
+        backend: "sim".to_string(),
+        runtime_profile: crate::RuntimeProfile::detect().fingerprint_hex8(),
+        run_config_digest,
+        seed_tree_root: task.run_config.seed(),
+        faultspec_digest: None,
+        oracle_version: None,
+        support_provider_version: None,
+        resource_limits: ledger_journal::ResourceLimits {
+            max_steps: task.run_config.max_steps() as u64,
+        },
+    };
+    Ok(ledger_explorer::identity::assemble_identity(&build, &context).digest())
 }
 
 pub fn workload_for(name: &str) -> SmallWorkload {
@@ -337,6 +411,35 @@ mod tests {
     use crate::queue::{InMemoryQueue, Task};
     use ledger_sim::RunConfig;
     use std::time::Duration;
+
+    #[test]
+    fn pinned_identity_rejects_before_execution() {
+        // A pinned identity must reject the task before the simulation runs,
+        // either because the worker build data is incomplete (dev builds) or
+        // because the assembled identity differs (any build). Both arms are
+        // fail-closed; neither lets a mismatched task execute.
+        let mut task = Task::new("pinned", RunConfig::default(), "trivial");
+        task.execution_identity = Some([0xab; 32]);
+        let error = execute_task(task).expect_err("pinned identity must reject the task");
+        assert!(
+            matches!(
+                error,
+                WorkerError::IdentityIncomplete { .. } | WorkerError::IdentityMismatch { .. }
+            ),
+            "fail-closed identity rejection, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn unpinned_task_records_its_identity() {
+        let task = Task::new("unpinned", RunConfig::default(), "trivial");
+        let result = execute_task(task).expect("unpinned task must run");
+        // The recorded digest follows the worker build: complete builds carry
+        // a digest, incomplete builds carry None (the control plane treats
+        // None as identity-incomplete).
+        let _ = result.execution_identity;
+        assert_eq!(result.task_id, "unpinned");
+    }
 
     #[test]
     fn run_one_produces_deterministic_root() {


### PR DESCRIPTION
ExecutionIdentity binds the build segment captured at compile time
(source revision, dirty state, engine version, toolchain, target,
profile, features, lockfile digest) with the run segment from runtime
context (SUT and guest artifacts, workload, program and input digests,
backend and runtime profile, RunConfig digest, seed-tree root,
faultspec and oracle versions, format versions, resource limits).
Canonical length-prefixed bytes with BLAKE3 domain separation live in
ledger-journal; host-side assembly stays in ledger-explorer.

The manifest carries the digest through its existing append-only
extensions slot, so the version-1 wire form is unchanged. Task records,
uploads, and statements carry the same digest, and root comparison
fails closed before comparison when identities differ or are
incomplete.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>