### PR TITLE
feat(statements): version 2 statement schema with three validation operations

### DIFF
--- a/crates/ledger-cli/src/cert_cmd.rs
+++ b/crates/ledger-cli/src/cert_cmd.rs
@@ -8,7 +8,8 @@ use ledger_explorer::certs::{CERT_MAX_BYTES, CertError, check_cert_bytes};
 use ledger_explorer::search::PersistentJournal;
 use ledger_explorer::services::ServiceError;
 use ledger_explorer::services::{
-    parse_statement, validate_cut_against_journal, validate_statement,
+    parse_statement, validate_cut_against_journal, validate_inclusion_minimal_cut,
+    validate_statement,
 };
 
 /// Errors from `ledger cert verify`.
@@ -54,9 +55,19 @@ fn to_verify_error(error: ServiceError) -> CertVerifyError {
 /// # Errors
 /// Returns [`CertVerifyError`] when the file cannot be read, parsed, validated,
 /// or bound to the supplied journal.
+/// Verifies a campaign certificate JSON file.
+///
+/// Reads `path` through a bounded reader and runs the named operation.
+/// `Journal` and `InclusionMinimal` require an explicit journal directory;
+/// `Statement` ignores it.
+///
+/// # Errors
+/// Returns [`CertVerifyError`] when the file cannot be read, parsed, validated,
+/// or bound to the supplied journal.
 pub fn run_verify(
     path: &Path,
     journal: Option<&Path>,
+    op: crate::CertVerifyOp,
     json: bool,
 ) -> Result<String, CertVerifyError> {
     let file = std::fs::File::open(path).map_err(CertVerifyError::Io)?;
@@ -67,14 +78,33 @@ pub fn run_verify(
         .map_err(CertVerifyError::Io)?;
     check_cert_bytes(raw.len()).map_err(CertVerifyError::Decode)?;
     let cert = parse_statement(&raw).map_err(to_verify_error)?;
-    let mode_label = if let Some(journal_dir) = journal {
-        let persistent =
-            PersistentJournal::open(journal_dir).map_err(CertVerifyError::JournalOpen)?;
-        validate_cut_against_journal(&cert, persistent.journal()).map_err(to_verify_error)?;
-        "journal-bound"
-    } else {
-        validate_statement(&cert).map_err(to_verify_error)?;
-        "statement-validated"
+    let mode_label = match op {
+        crate::CertVerifyOp::Statement => {
+            validate_statement(&cert).map_err(to_verify_error)?;
+            "statement-validated"
+        }
+        crate::CertVerifyOp::Journal => {
+            let Some(journal_dir) = journal else {
+                return Err(CertVerifyError::Verification(CertError::Schema(
+                    "journal mode requires --journal".into(),
+                )));
+            };
+            let persistent =
+                PersistentJournal::open(journal_dir).map_err(CertVerifyError::JournalOpen)?;
+            validate_cut_against_journal(&cert, persistent.journal()).map_err(to_verify_error)?;
+            "journal-bound"
+        }
+        crate::CertVerifyOp::InclusionMinimal => {
+            let Some(journal_dir) = journal else {
+                return Err(CertVerifyError::Verification(CertError::Schema(
+                    "inclusion-minimal mode requires --journal".into(),
+                )));
+            };
+            let persistent =
+                PersistentJournal::open(journal_dir).map_err(CertVerifyError::JournalOpen)?;
+            validate_inclusion_minimal_cut(&cert, persistent.journal()).map_err(to_verify_error)?;
+            "inclusion-minimal-verified"
+        }
     };
 
     if json {
@@ -90,10 +120,21 @@ pub fn run_verify(
             "findings_count": cert.findings_count,
             "solver_data": cert.solver_data.as_ref().map(|entry| serde_json::json!({
                 "cut": entry.cut.iter().map(ledger_format::hash_to_hex).collect::<Vec<_>>(),
-                "recorded_lower_bound": entry.recorded_lower_bound,
+                "cost": entry.cost,
                 "method": entry.method,
-                "horizon": entry.horizon
+                "horizon": entry.horizon,
+                "reproduced": entry.reproduced,
+                "baseline_passed": entry.baseline_passed,
+                "support_provider_version": entry.support_provider_version,
+                "witnesses": entry.witnesses.iter().map(ledger_format::hash_to_hex).collect::<Vec<_>>()
             })).unwrap_or(serde_json::Value::Null),
+            "journal_validation": cert.journal_validation.map(|v| match v {
+                ledger_explorer::certs::JournalValidation::Bound => "bound"
+            }),
+            "inclusion_minimal": cert.inclusion_minimal.map(|v| match v {
+                ledger_explorer::certs::InclusionMinimal::Minimal => true,
+                ledger_explorer::certs::InclusionMinimal::NotMinimal => false
+            }),
             "statistical": cert.statistical.as_ref().map(|entry| serde_json::json!({
                 "upper_p": entry.upper_p,
                 "confidence": entry.confidence,
@@ -116,11 +157,13 @@ pub fn run_verify(
         match &cert.solver_data {
             Some(entry) => {
                 out.push_str(&format!(
-                    "solver data: cut={} recorded_lower_bound={} method={} horizon={:?}\n",
+                    "solver data: cut={} cost={} method={} horizon={:?} reproduced={} baseline_passed={}\n",
                     entry.cut.len(),
-                    entry.recorded_lower_bound,
+                    entry.cost,
                     entry.method,
-                    entry.horizon
+                    entry.horizon,
+                    entry.reproduced,
+                    entry.baseline_passed
                 ));
             }
             None => out.push_str("solver data: none\n"),

--- a/crates/ledger-cli/src/lib.rs
+++ b/crates/ledger-cli/src/lib.rs
@@ -327,7 +327,22 @@ pub enum CertCommand {
         /// Directory of the persisted journal for journal-anchored validation.
         #[arg(long)]
         journal: Option<PathBuf>,
+        /// Selected operation: statement, journal, or inclusion-minimal.
+        /// Journal and inclusion-minimal require --journal.
+        #[arg(long, value_enum, default_value_t = CertVerifyOp::Statement)]
+        op: CertVerifyOp,
     },
+}
+
+/// The three distinct certificate operations the CLI names explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum CertVerifyOp {
+    /// Bounded statement validation without a journal.
+    Statement,
+    /// Journal-anchored observation and cut validation.
+    Journal,
+    /// Bounded inclusion-minimal fault-cut validation.
+    InclusionMinimal,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/ledger-cli/src/main.rs
+++ b/crates/ledger-cli/src/main.rs
@@ -164,8 +164,8 @@ fn main() -> ExitCode {
         Command::Completions { shell } => run_completions(*shell),
         Command::Ingest { input, fidelity } => run_ingest(&cli, input, *fidelity),
         Command::Cert { cmd } => match cmd {
-            ledger_cli::CertCommand::Verify { path, journal } => {
-                run_cert_verify(&cli, path, journal.as_deref())
+            ledger_cli::CertCommand::Verify { path, journal, op } => {
+                run_cert_verify(&cli, path, journal.as_deref(), *op)
             }
         },
         Command::Faults { cmd } => match cmd {
@@ -815,9 +815,10 @@ fn run_cert_verify(
     cli: &Cli,
     path: &Path,
     journal: Option<&Path>,
+    op: ledger_cli::CertVerifyOp,
 ) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let effective_json = cli.json || cli.ndjson;
-    match ledger_cli::cert_cmd::run_verify(path, journal, effective_json) {
+    match ledger_cli::cert_cmd::run_verify(path, journal, op, effective_json) {
         Ok(output) => {
             println!("{output}");
             Ok(ExitCode::SUCCESS)

--- a/crates/ledger-cli/tests/cert_cmd.rs
+++ b/crates/ledger-cli/tests/cert_cmd.rs
@@ -1,6 +1,8 @@
 use std::error::Error as _;
 use std::path::PathBuf;
 
+use ledger_cli::CertVerifyOp;
+use ledger_cli::cert_cmd::run_verify;
 use ledger_explorer::search::CampaignReport;
 use ledger_explorer::{
     CampaignCertificate, RecordedSolverData, ResolvedDependency, StatisticalBound,
@@ -38,7 +40,7 @@ fn cert_verify_human_valid() {
     let path = temp_path("valid-human");
     write_cert(&path, &json);
 
-    let out = ledger_cli::cert_cmd::run_verify(&path, None, false).unwrap();
+    let out = run_verify(&path, None, CertVerifyOp::Statement, false).unwrap();
     assert!(
         out.contains("certificate valid"),
         "output missing valid marker: {out}"
@@ -81,9 +83,13 @@ fn cert_verify_json_valid() {
             .expect("valid report must create a certificate");
     cert.solver_data = Some(RecordedSolverData {
         cut: vec![[3u8; 32], [4u8; 32]],
-        recorded_lower_bound: 1,
+        cost: 2,
         method: "test-method".into(),
         horizon: Some(64),
+        support_provider_version: None,
+        witnesses: Vec::new(),
+        reproduced: false,
+        baseline_passed: false,
     });
     cert.statistical = Some(StatisticalBound {
         upper_p: 0.01,
@@ -94,7 +100,7 @@ fn cert_verify_json_valid() {
     let path = temp_path("valid-json");
     write_cert(&path, &json);
 
-    let out = ledger_cli::cert_cmd::run_verify(&path, None, true).unwrap();
+    let out = run_verify(&path, None, CertVerifyOp::Statement, true).unwrap();
     assert!(out.contains("\"valid\":true"), "json missing valid: {out}");
     assert!(
         out.contains(&predicate_type_campaign_v1()),
@@ -139,7 +145,7 @@ fn cert_verify_tampered_predicate_fails() {
     let path = temp_path("tampered-predicate");
     write_cert(&path, &json);
 
-    let err = ledger_cli::cert_cmd::run_verify(&path, None, false).unwrap_err();
+    let err = run_verify(&path, None, CertVerifyOp::Statement, false).unwrap_err();
     let lower = err.to_string().to_lowercase();
     assert!(
         lower.contains("predicate") || lower.contains("verification") || lower.contains("schema"),
@@ -161,8 +167,13 @@ fn cert_verify_preserves_journal_open_error_source() {
     let journal_path = temp_path("journal-source-invalid");
     write_cert(&journal_path, "not a journal directory");
 
-    let error = ledger_cli::cert_cmd::run_verify(&cert_path, Some(&journal_path), false)
-        .expect_err("invalid journal path must fail");
+    let error = run_verify(
+        &cert_path,
+        Some(&journal_path),
+        CertVerifyOp::Journal,
+        false,
+    )
+    .expect_err("invalid journal path must fail");
     assert!(
         matches!(error, ledger_cli::cert_cmd::CertVerifyError::JournalOpen(_)),
         "journal open must keep its dedicated error variant: {error:?}"
@@ -180,10 +191,60 @@ fn cert_verify_preserves_journal_open_error_source() {
 fn cert_verify_invalid_json_schema_error() {
     let path = temp_path("invalid-json");
     write_cert(&path, r#"{"not": "a certificate"}"#);
-    let err = ledger_cli::cert_cmd::run_verify(&path, None, false).unwrap_err();
+    let err = run_verify(&path, None, CertVerifyOp::Statement, false).unwrap_err();
     let lower = err.to_string().to_lowercase();
     assert!(
         lower.contains("schema"),
         "invalid json should be schema error, got: {err}"
+    );
+}
+
+#[test]
+fn journal_mode_requires_explicit_journal() {
+    let report = make_report(10);
+    let cert =
+        CampaignCertificate::from_campaign(&report, "builder-test", Vec::new(), [1u8; 32], None)
+            .expect("valid report must create a certificate");
+    let path = temp_path("journal-required");
+    write_cert(&path, &cert.to_json().unwrap());
+    // Journal mode without --journal names its requirement explicitly.
+    let err = run_verify(&path, None, CertVerifyOp::Journal, false).unwrap_err();
+    assert!(
+        err.to_string().contains("requires --journal"),
+        "journal mode must require the journal: {err}"
+    );
+    let err = run_verify(&path, None, CertVerifyOp::InclusionMinimal, false).unwrap_err();
+    assert!(
+        err.to_string().contains("requires --journal"),
+        "inclusion-minimal mode must require the journal: {err}"
+    );
+}
+
+#[test]
+fn inclusion_minimal_mode_names_the_operation_and_refuses_campaign_statements() {
+    let report = make_report(10);
+    let cert =
+        CampaignCertificate::from_campaign(&report, "builder-test", Vec::new(), [1u8; 32], None)
+            .expect("valid report must create a certificate");
+    let cert_path = temp_path("minimal-campaign");
+    write_cert(&cert_path, &cert.to_json().unwrap());
+    // A journal directory is required and must open, but a campaign
+    // statement without a recorded fault cut is not causation evidence.
+    let journal_path = temp_path("minimal-campaign-journal");
+    std::fs::create_dir_all(&journal_path).unwrap();
+    let err = run_verify(
+        &cert_path,
+        Some(&journal_path),
+        CertVerifyOp::InclusionMinimal,
+        false,
+    )
+    .unwrap_err();
+    // The empty directory opens as an empty journal, and the campaign
+    // statement (no findings, zero digest) must fail closed: the concrete
+    // subject digest requirement binds before any cut check.
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("zero digest") || msg.contains("recorded cut"),
+        "inclusion-minimal mode must fail closed on a campaign statement: {err}"
     );
 }

--- a/crates/ledger-cli/tests/cli_tasks.rs
+++ b/crates/ledger-cli/tests/cli_tasks.rs
@@ -881,16 +881,26 @@ fn cert_verify_journal_mode_valid() {
     let cert_path = dir.join("cert.json");
     std::fs::write(&cert_path, cert.to_json().unwrap()).unwrap();
     // Journal binding should succeed.
-    let out = ledger_cli::cert_cmd::run_verify(&cert_path, Some(&journal_dir), false)
-        .expect("valid cert");
+    let out = ledger_cli::cert_cmd::run_verify(
+        &cert_path,
+        Some(&journal_dir),
+        ledger_cli::CertVerifyOp::Journal,
+        false,
+    )
+    .expect("valid cert");
     assert!(out.contains("certificate valid"), "{out}");
     assert!(
         out.contains("mode: journal-bound"),
         "mode label missing: {out}"
     );
     // JSON reports the exact journal-bound mode label.
-    let out_json =
-        ledger_cli::cert_cmd::run_verify(&cert_path, Some(&journal_dir), true).expect("json");
+    let out_json = ledger_cli::cert_cmd::run_verify(
+        &cert_path,
+        Some(&journal_dir),
+        ledger_cli::CertVerifyOp::Journal,
+        true,
+    )
+    .expect("json");
     let parsed: serde_json::Value = serde_json::from_str(&out_json).expect("json parse");
     assert_eq!(parsed["valid"], true);
     assert_eq!(parsed["mode"], "journal-bound");
@@ -955,8 +965,13 @@ fn cert_verify_journal_mode_wrong_root() {
         .expect("valid report must create a certificate");
     let cert_path = dir.join("cert.json");
     std::fs::write(&cert_path, cert.to_json().unwrap()).unwrap();
-    let err =
-        ledger_cli::cert_cmd::run_verify(&cert_path, Some(&journal_dir_b), false).unwrap_err();
+    let err = ledger_cli::cert_cmd::run_verify(
+        &cert_path,
+        Some(&journal_dir_b),
+        ledger_cli::CertVerifyOp::Journal,
+        false,
+    )
+    .unwrap_err();
     let msg = err.to_string().to_lowercase();
     assert!(
         msg.contains("subject digest mismatch") || msg.contains("mismatch"),
@@ -981,26 +996,34 @@ fn cert_verify_human_recorded_solver_data_label() {
             .expect("valid report must create a certificate");
     cert.solver_data = Some(RecordedSolverData {
         cut: vec![[3u8; 32]],
-        recorded_lower_bound: 2,
+        cost: 2,
         method: "m".into(),
         horizon: Some(64),
+        support_provider_version: None,
+        witnesses: Vec::new(),
+        reproduced: false,
+        baseline_passed: false,
     });
     let dir = temp_dir("cert-recorded-bound");
     let path = dir.join("cert.json");
     std::fs::write(&path, cert.to_json().unwrap()).unwrap();
-    let out = ledger_cli::cert_cmd::run_verify(&path, None, false).unwrap();
+    let out =
+        ledger_cli::cert_cmd::run_verify(&path, None, ledger_cli::CertVerifyOp::Statement, false)
+            .unwrap();
     assert!(
-        out.contains("recorded_lower_bound"),
+        out.contains("cost="),
         "human must identify recorded solver data: {out}"
     );
     assert!(
         !out.contains("proven"),
         "human output must not claim proof: {out}"
     );
-    let out_json = ledger_cli::cert_cmd::run_verify(&path, None, true).unwrap();
+    let out_json =
+        ledger_cli::cert_cmd::run_verify(&path, None, ledger_cli::CertVerifyOp::Statement, true)
+            .unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&out_json).unwrap();
     let solver_data = &parsed["solver_data"];
-    assert_eq!(solver_data["recorded_lower_bound"], 2);
+    assert_eq!(solver_data["cost"], 2);
 }
 
 #[test]
@@ -1010,7 +1033,9 @@ fn cert_verify_rejects_oversized_file() {
     // The bounded reader rejects 1 MiB plus one byte before JSON parsing.
     let oversized = vec![b'a'; 1024 * 1024 + 1];
     std::fs::write(&path, &oversized).unwrap();
-    let err = ledger_cli::cert_cmd::run_verify(&path, None, false).unwrap_err();
+    let err =
+        ledger_cli::cert_cmd::run_verify(&path, None, ledger_cli::CertVerifyOp::Statement, false)
+            .unwrap_err();
     let msg = err.to_string().to_lowercase();
     assert!(
         msg.contains("too large") || msg.contains("limit"),
@@ -1059,7 +1084,12 @@ fn cert_verify_rejects_oversized_via_bounded_reader() {
     let path_ok = dir.join("ok.json");
     std::fs::write(&path_ok, &json).unwrap();
     // Small cert verifies.
-    let ok = ledger_cli::cert_cmd::run_verify(&path_ok, None, false);
+    let ok = ledger_cli::cert_cmd::run_verify(
+        &path_ok,
+        None,
+        ledger_cli::CertVerifyOp::Statement,
+        false,
+    );
     assert!(ok.is_ok(), "small cert must verify: {ok:?}");
     // The bounded reader consumes at most the limit plus one byte.
     let path_big = dir.join("big.json");
@@ -1067,7 +1097,13 @@ fn cert_verify_rejects_oversized_via_bounded_reader() {
     big.push_str(&" ".repeat(1024 * 1024));
     assert!(big.len() > 1024 * 1024);
     std::fs::write(&path_big, &big).unwrap();
-    let err = ledger_cli::cert_cmd::run_verify(&path_big, None, false).unwrap_err();
+    let err = ledger_cli::cert_cmd::run_verify(
+        &path_big,
+        None,
+        ledger_cli::CertVerifyOp::Statement,
+        false,
+    )
+    .unwrap_err();
     let msg = err.to_string().to_lowercase();
     assert!(
         msg.contains("too large") || msg.contains("limit"),

--- a/crates/ledger-explorer/src/certs.rs
+++ b/crates/ledger-explorer/src/certs.rs
@@ -90,12 +90,39 @@ pub struct ResolvedDependency {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RecordedSolverData {
     pub cut: Vec<Hash>,
-    /// Value recorded by the solver when it emitted this data.
-    pub recorded_lower_bound: u64,
+    /// Exact cut cost recomputed from the journal fault model at emission.
+    pub cost: u64,
     pub method: String,
     /// Solver horizon recorded at emission time. `None` records an unbounded
-    /// solver configuration. Wave 1 does not use this value for traversal.
+    /// solver configuration. Inclusion-minimal validation refuses an
+    /// unbounded configuration because it cannot bound the walk.
     pub horizon: Option<usize>,
+    /// Support-provider version pinned at emission. Tampering with this value
+    /// after the fact is rejected by support-aware validation.
+    pub support_provider_version: Option<u64>,
+    /// Violation witnesses the cut was derived against.
+    pub witnesses: Vec<Hash>,
+    /// Strict replay with the recorded cut applied reproduced the violation.
+    pub reproduced: bool,
+    /// The no-fault baseline rerun passed.
+    pub baseline_passed: bool,
+}
+
+/// Journal-anchored validation result recorded in a statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum JournalValidation {
+    /// The statement bound to a journal: root matched and every cut member
+    /// existed in that journal and was faultable.
+    Bound,
+}
+
+/// Inclusion-minimal fault-cut validation result recorded when checked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InclusionMinimal {
+    /// No cut member is redundant: dropping any member loses hazard coverage.
+    Minimal,
+    /// At least one cut member is redundant.
+    NotMinimal,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -117,6 +144,10 @@ pub struct CampaignCertificate {
     pub findings_count: usize,
     pub solver_data: Option<RecordedSolverData>,
     pub statistical: Option<StatisticalBound>,
+    /// Result of journal-anchored validation when it has been run.
+    pub journal_validation: Option<JournalValidation>,
+    /// Result of bounded inclusion-minimal fault-cut validation when checked.
+    pub inclusion_minimal: Option<InclusionMinimal>,
     /// Execution-identity digest of the run that produced this statement.
     ///
     /// `None` on certificates emitted without identity binding; the
@@ -338,6 +369,8 @@ impl CampaignCertificate {
             findings_count: report.findings.len(),
             solver_data: None,
             statistical,
+            journal_validation: None,
+            inclusion_minimal: None,
             execution_identity,
         };
         certificate.verify()?;
@@ -404,11 +437,31 @@ impl CampaignCertificate {
                 serde_json::json!(hash_to_hex(identity));
         }
         if let Some(data) = &self.solver_data {
-            let mut solver_json = serde_json::json!({"cut":data.cut.iter().map(hash_to_hex).collect::<Vec<_>>(),"recordedLowerBound":data.recorded_lower_bound,"method":data.method});
+            let mut solver_json = serde_json::json!({"cut":data.cut.iter().map(hash_to_hex).collect::<Vec<_>>(),"cost":data.cost,"method":data.method,"reproduced":data.reproduced,"baselinePassed":data.baseline_passed});
             if let Some(horizon) = data.horizon {
                 solver_json["horizon"] = serde_json::json!(horizon);
             }
+            if let Some(version) = data.support_provider_version {
+                solver_json["supportProviderVersion"] = serde_json::json!(version);
+            }
+            if !data.witnesses.is_empty() {
+                solver_json["witnesses"] =
+                    serde_json::json!(data.witnesses.iter().map(hash_to_hex).collect::<Vec<_>>());
+            }
             p["solverData"] = solver_json;
+        }
+        if let Some(validation) = &self.journal_validation {
+            let label = match validation {
+                JournalValidation::Bound => "bound",
+            };
+            p["journalValidation"] = serde_json::json!(label);
+        }
+        if let Some(minimal) = &self.inclusion_minimal {
+            let label = match minimal {
+                InclusionMinimal::Minimal => true,
+                InclusionMinimal::NotMinimal => false,
+            };
+            p["inclusionMinimal"] = serde_json::json!(label);
         }
         if let Some(s) = &self.statistical {
             p["statistical"] =
@@ -461,7 +514,12 @@ impl CampaignCertificate {
             pred,
             "predicate",
             &["buildDefinition", "runDetails"],
-            &["solverData", "statistical"],
+            &[
+                "solverData",
+                "statistical",
+                "journalValidation",
+                "inclusionMinimal",
+            ],
         )?;
         let bd = get_obj(pred, "buildDefinition")?;
         check_object_fields(
@@ -528,8 +586,8 @@ impl CampaignCertificate {
             check_object_fields(
                 data,
                 "solverData",
-                &["cut", "recordedLowerBound", "method"],
-                &["horizon"],
+                &["cut", "cost", "method", "reproduced", "baselinePassed"],
+                &["horizon", "supportProviderVersion", "witnesses"],
             )?;
             let cut_arr = get_arr(data, "cut")?;
             if cut_arr.is_empty() {
@@ -548,11 +606,49 @@ impl CampaignCertificate {
                 check_string_bytes(text, "cut member")?;
                 cut.push(hex_to_hash(text).map_err(CertError::Schema)?);
             }
-            let recorded_lower_bound = data
-                .get("recordedLowerBound")
+            let cost = data
+                .get("cost")
                 .and_then(|value| value.as_u64())
-                .ok_or_else(|| CertError::Schema("recordedLowerBound".into()))?;
+                .ok_or_else(|| CertError::Schema("cost".into()))?;
             let method = get_str(data, "method")?.to_string();
+            let reproduced = data
+                .get("reproduced")
+                .and_then(|value| value.as_bool())
+                .ok_or_else(|| CertError::Schema("reproduced".into()))?;
+            let baseline_passed = data
+                .get("baselinePassed")
+                .and_then(|value| value.as_bool())
+                .ok_or_else(|| CertError::Schema("baselinePassed".into()))?;
+            let witnesses = if let Some(arr) = data.get("witnesses").and_then(|x| x.as_array()) {
+                if arr.len() > MAX_RESOLVED_DEPENDENCIES {
+                    return Err(CertError::Schema(format!(
+                        "witnesses exceeds {MAX_RESOLVED_DEPENDENCIES}"
+                    )));
+                }
+                let mut out = Vec::with_capacity(arr.len());
+                for value in arr {
+                    let text = value
+                        .as_str()
+                        .ok_or_else(|| CertError::Schema("witness".into()))?;
+                    check_string_bytes(text, "witness")?;
+                    out.push(hex_to_hash(text).map_err(CertError::Schema)?);
+                }
+                out
+            } else {
+                Vec::new()
+            };
+            let support_provider_version = if let Some(value) = data.get("supportProviderVersion") {
+                let raw = value
+                    .as_u64()
+                    .ok_or_else(|| CertError::Schema("supportProviderVersion".into()))?;
+                let converted = u64_to_usize_checked(raw, "supportProviderVersion")?;
+                Some(
+                    u64::try_from(converted)
+                        .map_err(|_| CertError::Schema("supportProviderVersion overflow".into()))?,
+                )
+            } else {
+                None
+            };
             let horizon = if let Some(value) = data.get("horizon") {
                 let raw = value
                     .as_u64()
@@ -569,9 +665,13 @@ impl CampaignCertificate {
             };
             Some(RecordedSolverData {
                 cut,
-                recorded_lower_bound,
+                cost,
                 method,
                 horizon,
+                support_provider_version,
+                witnesses,
+                reproduced,
+                baseline_passed,
             })
         } else {
             None
@@ -592,6 +692,27 @@ impl CampaignCertificate {
         } else {
             None
         };
+        let journal_validation = match pred.get("journalValidation").and_then(|x| x.as_str()) {
+            Some("bound") => Some(JournalValidation::Bound),
+            Some(other) => {
+                return Err(CertError::Schema(format!(
+                    "journalValidation must be `bound`, got {other:?}"
+                )));
+            }
+            None => None,
+        };
+        let inclusion_minimal = match pred.get("inclusionMinimal") {
+            Some(value) => match value.as_bool() {
+                Some(true) => Some(InclusionMinimal::Minimal),
+                Some(false) => Some(InclusionMinimal::NotMinimal),
+                None => {
+                    return Err(CertError::Schema(
+                        "inclusionMinimal must be a boolean".into(),
+                    ));
+                }
+            },
+            None => None,
+        };
         Ok(Self {
             subject,
             predicate_type: pt,
@@ -603,6 +724,8 @@ impl CampaignCertificate {
             findings_count,
             solver_data,
             statistical,
+            journal_validation,
+            inclusion_minimal,
             execution_identity,
         })
     }
@@ -690,12 +813,25 @@ impl CampaignCertificate {
             let maximum_cost = cut_count.checked_mul(MAX_EVENT_COST).ok_or_else(|| {
                 CertError::Verification("maximum recorded cut cost overflow".into())
             })?;
-            if data.recorded_lower_bound > maximum_cost {
+            if data.cost > maximum_cost {
                 return Err(CertError::Verification(format!(
-                    "recorded solver bound {} exceeds maximum cut cost {maximum_cost}",
-                    data.recorded_lower_bound
+                    "recorded cut cost {} exceeds maximum cut cost {maximum_cost}",
+                    data.cost
                 )));
             }
+        }
+        if self.inclusion_minimal.is_some() && self.solver_data.is_none() {
+            return Err(CertError::Verification(
+                "inclusionMinimal requires a recorded cut".into(),
+            ));
+        }
+        if self.journal_validation.is_some() && self.findings_count == 0 {
+            // A bound result records journal-anchored validation, which only
+            // runs on findings-bearing statements; a campaign statement that
+            // never bound to a journal must not claim the result.
+            return Err(CertError::Verification(
+                "journalValidation requires findings to validate against a journal".into(),
+            ));
         }
         if let Some(statistical) = &self.statistical {
             check_string_bytes(&statistical.method, "statistical.method")?;
@@ -746,6 +882,16 @@ impl CampaignCertificate {
                 "journal mode requires concrete subject digest; zero digest never binds".into(),
             ));
         }
+        if let Some(data) = &self.solver_data {
+            for witness in &data.witnesses {
+                if journal.get(witness).is_none() {
+                    return Err(CertError::Verification(format!(
+                        "forged witness: references unknown journal entry {:02x?}",
+                        &witness[..4]
+                    )));
+                }
+            }
+        }
         let subject_root = journal.root_hash();
         if subject_root != self.subject.digest {
             return Err(CertError::Verification(format!(
@@ -780,10 +926,10 @@ impl CampaignCertificate {
                 .checked_add(event_fault_cost(journal, id))
                 .ok_or_else(|| CertError::Verification("recomputed cut cost overflow".into()))
         })?;
-        if data.recorded_lower_bound > exact_cost {
+        if data.cost != exact_cost {
             return Err(CertError::Verification(format!(
-                "recorded solver bound {} exceeds recomputed cut cost {exact_cost}",
-                data.recorded_lower_bound
+                "recorded cut cost {} disagrees with recomputed cut cost {exact_cost}",
+                data.cost
             )));
         }
         Ok(())
@@ -832,6 +978,160 @@ impl CampaignCertificate {
         }
         self.verify_with_journal(journal)
     }
+
+    /// Bound the statement to a journal and verify the recorded cut is
+    /// inclusion-minimal: every member is essential, so no proper subset of
+    /// the cut still covers every witness derivation path.
+    ///
+    /// Requires a non-empty reproduced cut and a passing no-fault baseline;
+    /// a baseline violation may still produce a campaign statement, but it is
+    /// not fault-causation evidence and this operation refuses it.
+    pub fn verify_inclusion_minimal_with(
+        &self,
+        journal: &Journal,
+        policy: LineagePolicy,
+    ) -> Result<(), CertError> {
+        self.verify_inclusion_minimal_with_support(journal, policy, None)
+    }
+
+    /// Inclusion-minimal validation bound to an expected support-provider
+    /// version.
+    ///
+    /// When the statement records a support-provider version and an expected
+    /// version is supplied, the two must agree; a disagreement fails before
+    /// any traversal, so an altered support binding can never certify a cut.
+    pub fn verify_inclusion_minimal_with_support(
+        &self,
+        journal: &Journal,
+        policy: LineagePolicy,
+        expected_support_version: Option<u64>,
+    ) -> Result<(), CertError> {
+        self.verify_with_journal_with(journal, policy)?;
+        let Some(data) = &self.solver_data else {
+            return Err(CertError::Verification(
+                "inclusion-minimal validation requires a recorded cut".into(),
+            ));
+        };
+        if let (Some(recorded), Some(expected)) =
+            (data.support_provider_version, expected_support_version)
+            && recorded != expected
+        {
+            return Err(CertError::Verification(format!(
+                "support-provider version mismatch: statement records {recorded}, \
+                 expected {expected}"
+            )));
+        }
+        if !data.reproduced || !data.baseline_passed {
+            return Err(CertError::Verification(
+                "fault-cut extension requires a reproduced cut and a passing \
+                 no-fault baseline; a baseline violation is a campaign \
+                 statement, not fault-causation evidence"
+                    .into(),
+            ));
+        }
+        let Some(horizon) = data.horizon else {
+            return Err(CertError::Verification(
+                "inclusion-minimal validation requires a recorded solver \
+                 horizon to bound the traversal"
+                    .into(),
+            ));
+        };
+        if data.witnesses.is_empty() {
+            return Err(CertError::Verification(
+                "inclusion-minimal validation requires recorded witnesses".into(),
+            ));
+        }
+        let paths = collect_fault_paths_iterative(journal, &data.witnesses, horizon)?;
+        let cut: std::collections::BTreeSet<Hash> = data.cut.iter().copied().collect();
+        for path in &paths {
+            if path.iter().all(|id| !cut.contains(id)) {
+                return Err(CertError::Verification(
+                    "recorded cut misses a witness derivation path".into(),
+                ));
+            }
+        }
+        for member in &data.cut {
+            let essential = paths.iter().any(|path| {
+                path.contains(member) && path.iter().filter(|id| cut.contains(*id)).count() == 1
+            });
+            if !essential {
+                return Err(CertError::Verification(format!(
+                    "cut member {:02x?} is redundant: the recorded cut is not \
+                     inclusion-minimal",
+                    &member[..4]
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Journal-bound inclusion-minimal validation under the strict lineage
+    /// policy. See [`Self::verify_inclusion_minimal_with`].
+    pub fn verify_inclusion_minimal(&self, journal: &Journal) -> Result<(), CertError> {
+        self.verify_inclusion_minimal_with(journal, LineagePolicy::Strict)
+    }
+}
+
+/// Maximum derivation paths a bounded inclusion-minimal check will walk
+/// before failing closed: a cut whose witness closure is wider than this
+/// cannot be certified with the recorded horizon.
+const MAX_INCLUSION_PATHS: usize = 65536;
+
+/// Iteratively collect faultable derivation paths from `witnesses`, bounded
+/// by `horizon`.
+///
+/// The explicit stack keeps journal-derived graph depth off the call stack,
+/// and the per-walk visited set bounds re-expansion of shared ancestors, so
+/// a deep or wide graph cannot overflow or explode the walk. Returns an
+/// error when the path budget is exceeded, which fails the check closed.
+fn collect_fault_paths_iterative(
+    journal: &Journal,
+    witnesses: &[Hash],
+    horizon: usize,
+) -> Result<Vec<Vec<Hash>>, CertError> {
+    let mut paths = Vec::new();
+    for witness in witnesses {
+        let mut visited: std::collections::HashSet<(Hash, usize)> =
+            std::collections::HashSet::new();
+        let mut stack = vec![(*witness, 0usize, Vec::new())];
+        while let Some((current, depth, mut path)) = stack.pop() {
+            if depth > horizon {
+                if !path.is_empty() {
+                    paths.push(path);
+                    if paths.len() > MAX_INCLUSION_PATHS {
+                        return Err(CertError::Verification(format!(
+                            "inclusion-minimal check exceeds {MAX_INCLUSION_PATHS} paths"
+                        )));
+                    }
+                }
+                continue;
+            }
+            if !visited.insert((current, depth)) {
+                continue;
+            }
+            let Some(entry) = journal.get(&current) else {
+                continue;
+            };
+            if is_faultable(entry.data.kind) {
+                path.push(current);
+            }
+            if entry.data.parents.is_empty() {
+                if !path.is_empty() {
+                    paths.push(path);
+                    if paths.len() > MAX_INCLUSION_PATHS {
+                        return Err(CertError::Verification(format!(
+                            "inclusion-minimal check exceeds {MAX_INCLUSION_PATHS} paths"
+                        )));
+                    }
+                }
+            } else {
+                for parent in &entry.data.parents {
+                    stack.push((*parent, depth + 1, path.clone()));
+                }
+            }
+        }
+    }
+    Ok(paths)
 }
 
 impl CampaignReport {
@@ -1301,9 +1601,13 @@ mod tests {
         .expect("valid campaign must create a certificate");
         certificate.solver_data = Some(RecordedSolverData {
             cut: Vec::new(),
-            recorded_lower_bound: 0,
+            cost: 0,
             method: "solver-v1".into(),
             horizon: Some(64),
+            support_provider_version: None,
+            witnesses: Vec::new(),
+            reproduced: false,
+            baseline_passed: false,
         });
         let error = certificate.verify().expect_err("empty cut must fail");
         assert!(error.to_string().contains("non-empty cut"), "{error}");
@@ -1360,8 +1664,10 @@ mod tests {
                 .expect("certificate JSON must parse");
         value["predicate"]["solverData"] = serde_json::json!({
             "cut": [],
-            "recordedLowerBound": 0,
+            "cost": 0,
             "method": "solver-v1",
+            "reproduced": true,
+            "baselinePassed": true,
             "horizon": 64
         });
         let empty_cut = serde_json::to_string(&value).expect("JSON must serialize");
@@ -1370,8 +1676,10 @@ mod tests {
         let member = "01".repeat(32);
         value["predicate"]["solverData"] = serde_json::json!({
             "cut": [member.clone(), member],
-            "recordedLowerBound": 1,
+            "cost": 1,
             "method": "solver-v1",
+            "reproduced": true,
+            "baselinePassed": true,
             "horizon": 64
         });
         let duplicate = serde_json::to_string(&value).expect("JSON must serialize");
@@ -1415,11 +1723,18 @@ mod tests {
         let mut certificate =
             CampaignCertificate::from_campaign(&report, "builder", Vec::new(), [1u8; 32], None)
                 .expect("valid campaign must create a certificate");
+        let exact_cost = cut.iter().fold(0u64, |total, id| {
+            total.saturating_add(event_fault_cost(journal, id))
+        });
         certificate.solver_data = Some(RecordedSolverData {
-            recorded_lower_bound: u64::try_from(cut.len()).expect("test cut length must fit"),
+            cost: exact_cost,
             cut,
             method: "solver-v1".into(),
             horizon: Some(64),
+            support_provider_version: None,
+            witnesses: Vec::new(),
+            reproduced: true,
+            baseline_passed: true,
         });
         certificate
     }
@@ -1504,6 +1819,225 @@ mod tests {
         );
     }
 
+    fn deep_chain_journal(depth: usize) -> (Journal, Hash, Hash) {
+        let mut journal = Journal::new();
+        let mut parent = None;
+        let mut head = [0u8; 32];
+        let mut witness = [0u8; 32];
+        for i in 0..depth {
+            let id = journal
+                .append(
+                    EntryKind::Send,
+                    1,
+                    parent.map_or(Vec::new(), |p: Hash| vec![p]),
+                    Payload::Pair {
+                        left: (i as u64).wrapping_add(1),
+                        right: (i as u64).wrapping_add(2),
+                    },
+                )
+                .expect("append must succeed");
+            if i == 0 {
+                head = id;
+            }
+            parent = Some(id);
+            witness = id;
+        }
+        (journal, head, witness)
+    }
+
+    #[test]
+    fn inclusion_minimal_accepts_chain_cut_without_stack_overflow() {
+        // A 20k-deep single-parent chain behind a shallow statement horizon:
+        // the recorded horizon bounds the walk, and the iterative traversal
+        // never puts journal depth on the call stack.
+        let (journal, head, witness) = deep_chain_journal(20_000);
+        // The cut must sit inside the recorded horizon (64) of the witness;
+        // the head of a 20k chain is far beyond it.
+        let mut cut = Vec::new();
+        let mut current = Some(witness);
+        for _ in 0..16 {
+            current = current
+                .and_then(|id| journal.get(&id))
+                .and_then(|e| e.data.parents.first().copied());
+        }
+        let within_horizon = current.expect("chain must extend 16 levels");
+        cut.push(within_horizon);
+        let mut certificate = journal_certificate(&journal, cut);
+        certificate
+            .solver_data
+            .as_mut()
+            .expect("solver data present")
+            .witnesses = vec![witness];
+        certificate
+            .verify_inclusion_minimal(&journal)
+            .expect("the within-horizon chain cut must be inclusion-minimal");
+        assert_ne!(
+            head, within_horizon,
+            "the deep head stays outside the horizon"
+        );
+    }
+
+    #[test]
+    fn iterative_traversal_handles_deep_chain_without_recursion() {
+        // The traversal itself must survive graph depth far beyond any
+        // reasonable call-stack budget: 100k levels with no recursion.
+        let (journal, _, witness) = deep_chain_journal(100_000);
+        let paths = collect_fault_paths_iterative(&journal, &[witness], 100_000)
+            .expect("deep walk must complete within the path budget");
+        assert_eq!(paths.len(), 1, "a chain has exactly one witness path");
+        assert_eq!(
+            paths[0].len(),
+            100_000,
+            "every faultable chain level lands on the path"
+        );
+    }
+
+    #[test]
+    fn inclusion_minimal_rejects_redundant_cut_member() {
+        let (journal, head, witness) = deep_chain_journal(32);
+        // Cut with both the head and the witness: the witness is redundant
+        // because every path through the witness also passes the head.
+        let mut certificate = journal_certificate(&journal, vec![head, witness]);
+        certificate
+            .solver_data
+            .as_mut()
+            .expect("solver data present")
+            .witnesses = vec![witness];
+        let error = certificate
+            .verify_inclusion_minimal(&journal)
+            .expect_err("redundant member must fail");
+        assert!(
+            error.to_string().contains("redundant"),
+            "error must name the redundancy: {error}"
+        );
+    }
+
+    #[test]
+    fn inclusion_minimal_requires_reproduction_and_baseline() {
+        let (journal, head, witness) = deep_chain_journal(8);
+        let mut certificate = journal_certificate(&journal, vec![head]);
+        certificate
+            .solver_data
+            .as_mut()
+            .expect("solver data present")
+            .witnesses = vec![witness];
+        let data = certificate
+            .solver_data
+            .as_mut()
+            .expect("solver data present");
+        data.reproduced = false;
+        let error = certificate
+            .verify_inclusion_minimal(&journal)
+            .expect_err("an unreproduced cut is campaign data, not fault evidence");
+        assert!(
+            error.to_string().contains("reproduced"),
+            "error must name the missing reproduction: {error}"
+        );
+
+        let mut certificate = journal_certificate(&journal, vec![head]);
+        certificate
+            .solver_data
+            .as_mut()
+            .expect("solver data present")
+            .witnesses = vec![witness];
+        certificate
+            .solver_data
+            .as_mut()
+            .expect("solver data present")
+            .baseline_passed = false;
+        let error = certificate
+            .verify_inclusion_minimal(&journal)
+            .expect_err("a violating baseline is a campaign statement, not causation");
+        assert!(
+            error.to_string().contains("baseline"),
+            "error must name the baseline: {error}"
+        );
+    }
+
+    #[test]
+    fn altered_support_version_fails_statement_validation() {
+        // A real chain journal so cut membership and exact-cost checks pass
+        // before the support-version gate is exercised.
+        let (journal, head, witness) = deep_chain_journal(8);
+        let mut certificate = journal_certificate(&journal, vec![head]);
+        certificate
+            .solver_data
+            .as_mut()
+            .expect("solver data present")
+            .witnesses = vec![witness];
+        certificate
+            .solver_data
+            .as_mut()
+            .expect("solver data present")
+            .support_provider_version = Some(1);
+        // The statement records which support-provider version derived its
+        // cut; tampering with that binding is a schema-level integrity break.
+        let json = certificate.to_json().expect("certificate serializes");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&json).expect("certificate JSON must parse");
+        value["predicate"]["solverData"]["supportProviderVersion"] = serde_json::json!(2);
+        let tampered = serde_json::to_string(&value).expect("JSON must serialize");
+        let decoded = CampaignCertificate::from_json(&tampered).expect("schema must decode");
+        assert_eq!(
+            decoded
+                .solver_data
+                .as_ref()
+                .expect("solver data present")
+                .support_provider_version,
+            Some(2),
+            "the altered version must parse"
+        );
+        // Support binding is checked by the support-aware journal operation:
+        // a statement claiming one version while carrying another fails closed
+        // before any traversal.
+        let mut consistent = decoded.clone();
+        consistent
+            .solver_data
+            .as_mut()
+            .expect("solver data present")
+            .support_provider_version = Some(1);
+        assert!(
+            consistent
+                .verify_inclusion_minimal_with_support(&journal, LineagePolicy::Strict, Some(1))
+                .is_ok(),
+            "a statement matching the expected provider version must pass"
+        );
+        let error = decoded
+            .verify_inclusion_minimal_with_support(&journal, LineagePolicy::Strict, Some(1))
+            .expect_err("altered support version must fail support-bound validation");
+        assert!(
+            error
+                .to_string()
+                .contains("support-provider version mismatch"),
+            "error must name the support binding: {error}"
+        );
+    }
+
+    #[test]
+    fn statement_round_trips_journal_validation_and_minimality_results() {
+        let report = with_finding();
+        let mut certificate =
+            CampaignCertificate::from_campaign(&report, "b", Vec::new(), [1u8; 32], None)
+                .expect("valid campaign must create a certificate");
+        certificate.journal_validation = Some(JournalValidation::Bound);
+        certificate.inclusion_minimal = Some(InclusionMinimal::Minimal);
+        let json = certificate.to_json().expect("certificate serializes");
+        assert!(json.contains("journalValidation"), "{json}");
+        assert!(json.contains("inclusionMinimal"), "{json}");
+        let decoded = CampaignCertificate::from_json(&json).expect("certificate parses");
+        assert_eq!(decoded.journal_validation, Some(JournalValidation::Bound));
+        assert_eq!(decoded.inclusion_minimal, Some(InclusionMinimal::Minimal));
+        // Unknown values fail closed.
+        let mut value: serde_json::Value =
+            serde_json::from_str(&json).expect("certificate JSON must parse");
+        value["predicate"]["journalValidation"] = serde_json::json!("unbound");
+        let bad = serde_json::to_string(&value).expect("JSON must serialize");
+        assert!(
+            CampaignCertificate::from_json(&bad).is_err(),
+            "unknown journalValidation label must fail"
+        );
+    }
+
     #[test]
     fn certificate_surfaces_contain_no_future_claim_wording() {
         let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -1512,10 +2046,16 @@ mod tests {
             manifest.join("../ledger-cli/src/cert_cmd.rs"),
             manifest.join("../../README.md"),
         ];
+        // Stage 2 statements are unsigned. Public text must not claim
+        // trust guarantees the format does not provide, and the unverified
+        // solver bound wording is gone with the field. Every phrase is
+        // concatenated so this test never matches its own source.
         let forbidden = [
-            ["inclusion", "-minimal"].concat(),
-            ["support", " path"].concat(),
-            ["support", "-path"].concat(),
+            ["authent", "ic"].concat(),
+            ["non-", "repudiation"].concat(),
+            ["complete", "ness"].concat(),
+            ["global", " optimum"].concat(),
+            ["tamper", "-proof"].concat(),
             ["proven", " lower bound"].concat(),
             ["optimal", "ity"].concat(),
         ];
@@ -1525,7 +2065,7 @@ mod tests {
             for phrase in &forbidden {
                 assert!(
                     !lower.contains(phrase),
-                    "{} contains future claim wording `{phrase}`",
+                    "{} contains forbidden claim wording `{phrase}`",
                     file.display()
                 );
             }

--- a/crates/ledger-explorer/src/services.rs
+++ b/crates/ledger-explorer/src/services.rs
@@ -5,7 +5,7 @@
 //! certificate surfaces. Callers outside the explorer crate route through
 //! them instead of reaching into implementation modules.
 
-use crate::certs::{CampaignCertificate, CertError, ResolvedDependency};
+use crate::certs::{CampaignCertificate, CertError, LineagePolicy, ResolvedDependency};
 use crate::ldfi::{self, FaultHypothesis};
 use crate::maxsat;
 use crate::minimizer::{self, MinimizationReport, MinimizeError, MinimizedRepro};
@@ -166,5 +166,37 @@ pub fn validate_cut_against_journal(
     journal: &Journal,
 ) -> Result<(), ServiceError> {
     certificate.verify_with_journal(journal)?;
+    Ok(())
+}
+
+/// Bind a statement to a journal and verify the recorded cut is
+/// inclusion-minimal under the strict lineage policy.
+///
+/// Refuses statements whose cut is not reproduced or whose no-fault baseline
+/// violates: those are campaign statements, not fault-causation evidence.
+pub fn validate_inclusion_minimal_cut(
+    certificate: &CampaignCertificate,
+    journal: &Journal,
+) -> Result<(), ServiceError> {
+    certificate.verify_inclusion_minimal(journal)?;
+    Ok(())
+}
+
+/// Inclusion-minimal validation bound to the support provider that derived
+/// the recorded cut.
+///
+/// The recorded support-provider version must match the provider actually
+/// used; a disagreement fails before traversal, so an altered support binding
+/// can never certify a cut.
+pub fn validate_inclusion_minimal_cut_with_support(
+    certificate: &CampaignCertificate,
+    journal: &Journal,
+    support_version: u64,
+) -> Result<(), ServiceError> {
+    certificate.verify_inclusion_minimal_with_support(
+        journal,
+        LineagePolicy::Strict,
+        Some(support_version),
+    )?;
     Ok(())
 }

--- a/crates/ledger-explorer/src/solver/maxsat.rs
+++ b/crates/ledger-explorer/src/solver/maxsat.rs
@@ -181,9 +181,13 @@ impl MaxSatSolver {
         } else {
             Some(crate::certs::RecordedSolverData {
                 cut: solution.cut,
-                recorded_lower_bound: solution.lower_bound_proof.unsat_core_cost,
+                cost: solution.total_cost,
                 method: solution.lower_bound_proof.method.to_string(),
                 horizon: self.inner.config.max_horizon,
+                support_provider_version: self.inner.config.support_version,
+                witnesses: verdict.witnesses.clone(),
+                reproduced: false,
+                baseline_passed: false,
             })
         };
         Ok((hypotheses, solver_data))

--- a/crates/ledger-explorer/src/solver/tests.rs
+++ b/crates/ledger-explorer/src/solver/tests.rs
@@ -204,7 +204,7 @@ fn maxsat_solver_matches_hitting_set_optimum() {
         .expect("certificate solve must succeed");
     let ext = ext.expect("non-empty solve must return recorded solver data");
     assert_eq!(ext.method, "mcs-lower-bound-v1");
-    assert!(ext.recorded_lower_bound <= got[0].total_cost);
+    assert_eq!(ext.cost, got[0].total_cost, "recorded cost must be exact");
 }
 
 #[test]

--- a/crates/ledger-explorer/tests/certificate_emission.rs
+++ b/crates/ledger-explorer/tests/certificate_emission.rs
@@ -113,9 +113,9 @@ fn recorded_solver_data_from_real_cut_verifies() {
         .expect("weighted MaxSAT solve must succeed");
     let extension = extension.expect("non-empty solve must return recorded solver data");
     assert!(!extension.cut.is_empty(), "the real cut must be non-empty");
-    assert!(
-        extension.recorded_lower_bound <= hypotheses[0].total_cost,
-        "the recorded bound must not exceed the solved cut cost"
+    assert_eq!(
+        extension.cost, hypotheses[0].total_cost,
+        "the recorded cost must equal the solved cut cost"
     );
 
     let mut certificate = CampaignCertificate::from_campaign(
@@ -154,8 +154,8 @@ fn recorded_solver_data_from_real_cut_verifies() {
         "the recorded solver horizon must survive the roundtrip"
     );
 
-    // A recorded bound above the maximum cut cost must fail validation.
-    let tampered_bound = certificate
+    // A recorded cost above the maximum cut cost must fail validation.
+    let tampered_cost = certificate
         .solver_data
         .as_ref()
         .map(|data| data.cut.len() as u64 * MAX_EVENT_COST + 1)
@@ -163,12 +163,16 @@ fn recorded_solver_data_from_real_cut_verifies() {
     let mut tampered = certificate.clone();
     tampered.solver_data = Some(ledger_explorer::RecordedSolverData {
         cut: certificate.solver_data.as_ref().unwrap().cut.clone(),
-        recorded_lower_bound: tampered_bound,
+        cost: tampered_cost,
         method: extension.method.clone(),
         horizon: extension.horizon,
+        support_provider_version: extension.support_provider_version,
+        witnesses: extension.witnesses.clone(),
+        reproduced: extension.reproduced,
+        baseline_passed: extension.baseline_passed,
     });
     assert!(
         tampered.verify().is_err(),
-        "verify must reject recorded bound {tampered_bound} above the cut cost"
+        "verify must reject recorded cost {tampered_cost} above the cut cost"
     );
 }

--- a/crates/ledger-explorer/tests/corpus_v2_gate.rs
+++ b/crates/ledger-explorer/tests/corpus_v2_gate.rs
@@ -207,13 +207,13 @@ fn ldfi_finds_every_v2_bug_with_valid_minimal_certificate() {
         );
         let upper = (cert.cut.len() as u64).saturating_mul(MAX_EVENT_COST);
         assert!(
-            cert.recorded_lower_bound <= upper,
-            "{name}: recorded solver bound {} must be <= cut.len()*{MAX_EVENT_COST} ({upper})",
-            cert.recorded_lower_bound
+            cert.cost <= upper,
+            "{name}: recorded cut cost {} must be <= cut.len()*{MAX_EVENT_COST} ({upper})",
+            cert.cost
         );
         let hyp = ledger_explorer::ldfi::FaultHypothesis {
             events: cert.cut.clone(),
-            total_cost: cert.recorded_lower_bound,
+            total_cost: cert.cost,
             explanation: "mcs cut".to_string(),
         };
         let schedule = hypothesis_to_schedule(&hyp, &run.journal);

--- a/crates/ledger-explorer/tests/mcs_corpus_gate.rs
+++ b/crates/ledger-explorer/tests/mcs_corpus_gate.rs
@@ -68,13 +68,13 @@ fn mcs_certificates_on_bug_corpus_v1() {
         // faultable kind, bounded by the shared cost-model maximum.
         let upper = (cert.cut.len() as u64).saturating_mul(MAX_EVENT_COST);
         assert!(
-            cert.recorded_lower_bound <= upper,
-            "{name}: recorded solver bound {} must be <= cut.len()*{MAX_EVENT_COST} ({upper})",
-            cert.recorded_lower_bound
+            cert.cost <= upper,
+            "{name}: recorded cut cost {} must be <= cut.len()*{MAX_EVENT_COST} ({upper})",
+            cert.cost
         );
-        assert!(
-            cert.recorded_lower_bound <= hyps[0].total_cost,
-            "{name}: recorded solver bound must not exceed total_cost"
+        assert_eq!(
+            cert.cost, hyps[0].total_cost,
+            "{name}: recorded cut cost must equal the hypothesis cost"
         );
 
         // Map cut to executable fault schedule and verify replay reproduces
@@ -82,7 +82,7 @@ fn mcs_certificates_on_bug_corpus_v1() {
         // full schedule over-blocks progress.
         let hyp = ledger_explorer::ldfi::FaultHypothesis {
             events: cert.cut.clone(),
-            total_cost: cert.recorded_lower_bound,
+            total_cost: cert.cost,
             explanation: "mcs cut".to_string(),
         };
         let schedule = hypothesis_to_schedule(&hyp, &run.journal);
@@ -108,10 +108,10 @@ fn mcs_certificates_on_bug_corpus_v1() {
 
         let mut violated = holds(&schedule);
         println!(
-            "{name} full schedule violated={} cut_len={} lb={} schedule_len={}",
+            "{name} full schedule violated={} cut_len={} cost={} schedule_len={}",
             violated,
             cert.cut.len(),
-            cert.recorded_lower_bound,
+            cert.cost,
             schedule.len()
         );
         if !violated {
@@ -149,7 +149,7 @@ fn mcs_certificates_on_bug_corpus_v1() {
             "{name}: fault-injected replay must reproduce the violation"
         );
 
-        table.push((name.clone(), cert.cut.len(), cert.recorded_lower_bound));
+        table.push((name.clone(), cert.cut.len(), cert.cost));
         checked += 1;
     }
 

--- a/crates/ledger-explorer/tests/public_api_inventory.rs
+++ b/crates/ledger-explorer/tests/public_api_inventory.rs
@@ -18,7 +18,9 @@
 use ledger_explorer::services::{
     ServiceError, emit_statement, ldfi_solve, minimize_decisions, minimize_finding,
     parse_statement, replay_faults, replay_prefix, replay_strict, run_campaign,
-    schedule_from_hypothesis, search_first, validate_cut_against_journal, validate_statement,
+    schedule_from_hypothesis, search_first, validate_cut_against_journal,
+    validate_inclusion_minimal_cut, validate_inclusion_minimal_cut_with_support,
+    validate_statement,
 };
 use ledger_explorer::{
     AssertionOracle, CampaignCertificate, CampaignReport, CertError, ClauseCache, CoverageBuilder,

--- a/crates/ledger-explorer/tests/services.rs
+++ b/crates/ledger-explorer/tests/services.rs
@@ -4,7 +4,7 @@
 use ledger_explorer::services::{
     ServiceError, emit_statement, ldfi_solve, minimize_decisions, parse_statement, replay_faults,
     replay_prefix, replay_strict, run_campaign, schedule_from_hypothesis, search_first,
-    validate_cut_against_journal, validate_statement,
+    validate_cut_against_journal, validate_inclusion_minimal_cut, validate_statement,
 };
 use ledger_explorer::solver::SolverConfig;
 use ledger_explorer::{CampaignReport, CertError, Finding, Oracle, PropertyOracle, Workload};
@@ -270,5 +270,27 @@ fn validate_cut_against_journal_rejects_zero_digest_binding() {
     assert!(
         matches!(err, ServiceError::Cert(CertError::Verification(_))),
         "typed binding error: {err:?}"
+    );
+}
+
+#[test]
+fn validate_inclusion_minimal_cut_refuses_campaign_statements() {
+    let report: CampaignReport =
+        run_campaign(&OutcomeWorkload(99), &final_is(7), config(8), 1).expect("campaign must run");
+    assert!(
+        !report.findings.is_empty(),
+        "the mismatched oracle must produce a finding"
+    );
+    let certificate = emit_statement(&report, "builder", Vec::new(), [1u8; 32], None)
+        .expect("statement must emit");
+    let journal = report.findings[0].run.journal.clone();
+    // The operation names the third distinct check: inclusion-minimal
+    // fault-cut validation. A campaign statement without a recorded cut is
+    // not fault-causation evidence and must fail closed.
+    let err = validate_inclusion_minimal_cut(&certificate, &journal)
+        .expect_err("campaign statements carry no fault cut");
+    assert!(
+        matches!(err, ServiceError::Cert(CertError::Verification(_))),
+        "typed minimality error: {err:?}"
     );
 }

--- a/crates/ledger-explorer/tests/solver_cross_engine.rs
+++ b/crates/ledger-explorer/tests/solver_cross_engine.rs
@@ -189,14 +189,14 @@ fn builtin_bnb_is_deterministic_valid_and_minimal_on_randomized_encodings() {
             "case {index}: the builtin cost must be deterministic"
         );
         assert_eq!(
-            extension_a.recorded_lower_bound, extension_b.recorded_lower_bound,
-            "case {index}: the recorded solver bound must be deterministic"
+            extension_a.cost, extension_b.cost,
+            "case {index}: the recorded cut cost must be deterministic"
         );
         assert_cut_valid_and_minimal(encoding, &extension_a.cut);
         assert_cost_consistent(&case.journal, &extension_a.cut, first_cost);
-        assert!(
-            extension_a.recorded_lower_bound <= first_cost,
-            "case {index}: the recorded solver bound must not exceed the cut cost"
+        assert_eq!(
+            extension_a.cost, first_cost,
+            "case {index}: the recorded cut cost must equal the solved cost"
         );
     }
 }
@@ -243,23 +243,23 @@ fn bnb_and_cadical_agree_on_randomized_bounded_encodings() {
         // COST CONSISTENCY for both cuts.
         assert_cost_consistent(&case.journal, &builtin_ext.cut, builtin_cost);
         assert_cost_consistent(&case.journal, &cadical_ext.cut, cadical_cost);
-        // CERTIFICATE PARITY: same method, same lower bound, bound <= cost.
+        // CERTIFICATE PARITY: same method, same cut cost, cost == solved.
         assert_eq!(
             builtin_ext.method, cadical_ext.method,
-            "case {index}: the lower-bound method must match across engines"
+            "case {index}: the cost method must match across engines"
         );
         assert_eq!(
-            builtin_ext.recorded_lower_bound, cadical_ext.recorded_lower_bound,
-            "case {index}: the recorded solver bounds must agree across engines"
+            builtin_ext.cost, cadical_ext.cost,
+            "case {index}: the recorded cut costs must agree across engines"
         );
-        assert!(
-            builtin_ext.recorded_lower_bound <= builtin_cost,
-            "case {index}: the bound must never exceed the cut cost"
+        assert_eq!(
+            builtin_ext.cost, builtin_cost,
+            "case {index}: the recorded cost must equal the solved cost"
         );
         println!(
-            "case {index}: hard={} builtin_cost={builtin_cost} cadical_cost={cadical_cost} recorded_bound={} builtin_cut={} cadical_cut={}",
+            "case {index}: hard={} builtin_cost={builtin_cost} cadical_cost={cadical_cost} recorded_cost={} builtin_cut={} cadical_cut={}",
             encoding.hard.len(),
-            builtin_ext.recorded_lower_bound,
+            builtin_ext.cost,
             builtin_ext.cut.len(),
             cadical_ext.cut.len(),
         );
@@ -299,9 +299,9 @@ fn cadical_request_falls_back_to_builtin_truthfully_without_the_feature() {
     let cost = hypotheses[0].total_cost;
     assert_cut_valid_and_minimal(&encoding, &extension.cut);
     assert_cost_consistent(&case.journal, &extension.cut, cost);
-    assert!(
-        extension.recorded_lower_bound <= cost,
-        "the recorded solver bound must not exceed the cut cost"
+    assert_eq!(
+        extension.cost, cost,
+        "the recorded cut cost must equal the solved cost"
     );
     assert_eq!(
         extension.horizon,


### PR DESCRIPTION
Statements carry the execution-identity digest, support-provider
version, exact cut cost, solver and horizon configuration,
journal-validation result, and inclusion-minimal result. The unverified
lower-bound field is removed. Fault-cut extensions require a reproduced
cut and a passing no-fault baseline; a baseline violation yields a
campaign statement that cannot carry fault-causation evidence.

Three distinct operations replace the overloaded verify: bounded
statement validation, journal-anchored cut validation against an
explicit journal, and bounded inclusion-minimal fault-cut validation.
Traversal is iterative with an explicit stack and bounds are enforced
before allocation: 1 MiB statements, 4096 dependencies, 4096-byte
strings.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>