### PR TITLE
feat(support): typed support semantics with versioned providers

### DIFF
--- a/crates/ledger-explorer/src/lib.rs
+++ b/crates/ledger-explorer/src/lib.rs
@@ -24,6 +24,7 @@ pub mod search;
 pub mod solver;
 pub mod solver_cache;
 pub mod solver_state;
+pub mod support;
 pub mod workloads;
 
 pub use attest_uri::{
@@ -69,4 +70,8 @@ pub use solver_cache::{ClauseCache, WeightedClause};
 pub use solver_state::{
     COST_MODEL_VERSION, PersistedClosure, PersistedHypothesis, SolverStateArtifact,
     SolverStateError, fingerprint, load as load_solver_state, save as save_solver_state,
+};
+pub use support::{
+    StaticSupportProvider, SupportError, SupportExpr, SupportOutcome, SupportProvider, all_of_ids,
+    entry_ids_by,
 };

--- a/crates/ledger-explorer/src/reference/registry.rs
+++ b/crates/ledger-explorer/src/reference/registry.rs
@@ -1,8 +1,14 @@
 use super::sims::{
-    mini_2pc, mini_cassandra, mini_cloud_az_double_assign, mini_cloud_config_drift,
-    mini_cloud_instance_flap, mini_cloud_quota_retry_storm, mini_hdfs, mini_hdfs_lease_expiry,
-    mini_leader_stepdown, mini_lease_timer_race, mini_membership_churn, mini_partition_retry_dup,
-    mini_reorder_lost_update, mini_restart_dup_append, mini_zab,
+    mini_2pc, mini_2pc_support, mini_cassandra, mini_cassandra_support,
+    mini_cloud_az_double_assign, mini_cloud_az_double_assign_support, mini_cloud_config_drift,
+    mini_cloud_config_drift_support, mini_cloud_instance_flap, mini_cloud_instance_flap_support,
+    mini_cloud_quota_retry_storm, mini_cloud_quota_retry_storm_support, mini_hdfs,
+    mini_hdfs_lease_expiry, mini_hdfs_lease_expiry_support, mini_hdfs_support,
+    mini_kv_stale_read_support, mini_leader_stepdown, mini_leader_stepdown_support,
+    mini_lease_timer_race, mini_lease_timer_race_support, mini_membership_churn,
+    mini_membership_churn_support, mini_partition_retry_dup, mini_partition_retry_dup_support,
+    mini_reorder_lost_update, mini_reorder_lost_update_support, mini_restart_dup_append,
+    mini_restart_dup_append_support, mini_zab, mini_zab_support,
 };
 use crate::oracle::{HistoryOracle, KeyValueSpec, Oracle, PropertyOracle, Verdict};
 use crate::search::Finding;
@@ -62,6 +68,10 @@ pub struct CorpusScenario {
     /// schedule exploration. The space is derived from a seed-0 probe run,
     /// never from a violating run.
     pub fault_space: fn() -> Result<Vec<SimFault>, String>,
+    /// Explicit support model for this scenario's planted violation. The
+    /// provider digest and version join solver cache keys, so a model change
+    /// never reuses derived clauses.
+    pub support: fn(&Journal) -> crate::support::SupportExpr,
 }
 
 /// Every bug-corpus-v1 scenario in manifest-name order.
@@ -75,6 +85,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: zab_property,
             },
             fault_space: four_link_faults,
+            support: mini_zab_support,
         },
         CorpusScenario {
             name: "mini-hdfs-double-grant",
@@ -84,6 +95,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: hdfs_property,
             },
             fault_space: four_link_faults,
+            support: mini_hdfs_support,
         },
         CorpusScenario {
             name: "mini-cassandra-stale-read",
@@ -93,6 +105,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: cassandra_property,
             },
             fault_space: four_link_faults,
+            support: mini_cassandra_support,
         },
         CorpusScenario {
             name: "mini-2pc-coordinator-crash",
@@ -102,6 +115,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: two_pc_property,
             },
             fault_space: four_link_faults,
+            support: mini_2pc_support,
         },
         CorpusScenario {
             name: "mini-leader-stepdown",
@@ -111,6 +125,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: leader_stepdown_property,
             },
             fault_space: four_link_faults,
+            support: mini_leader_stepdown_support,
         },
         CorpusScenario {
             name: "mini-membership-churn",
@@ -120,6 +135,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: membership_churn_property,
             },
             fault_space: four_link_faults,
+            support: mini_membership_churn_support,
         },
         CorpusScenario {
             name: "mini-hdfs-lease-expiry",
@@ -129,12 +145,14 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: hdfs_lease_expiry_property,
             },
             fault_space: four_link_faults,
+            support: mini_hdfs_lease_expiry_support,
         },
         CorpusScenario {
             name: "mini-kv-stale-read",
             base_seed: [0; 32],
             runner: CorpusRunner::MiniKv,
             fault_space: mini_kv_faults,
+            support: mini_kv_stale_read_support,
         },
         CorpusScenario {
             name: "mini-reorder-lost-update",
@@ -144,6 +162,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: reorder_lost_update_property,
             },
             fault_space: four_link_faults,
+            support: mini_reorder_lost_update_support,
         },
         CorpusScenario {
             name: "mini-lease-timer-race",
@@ -153,6 +172,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: lease_timer_race_property,
             },
             fault_space: four_link_faults,
+            support: mini_lease_timer_race_support,
         },
         CorpusScenario {
             name: "mini-restart-dup-append",
@@ -162,6 +182,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: restart_dup_append_property,
             },
             fault_space: appender_chain_faults,
+            support: mini_restart_dup_append_support,
         },
         CorpusScenario {
             name: "mini-partition-retry-dup",
@@ -171,6 +192,7 @@ pub fn corpus_scenarios() -> Vec<CorpusScenario> {
                 property: partition_retry_dup_property,
             },
             fault_space: client_server_faults,
+            support: mini_partition_retry_dup_support,
         },
     ]
 }
@@ -226,6 +248,7 @@ pub fn corpus_v2_scenarios() -> Vec<CorpusScenario> {
                 property: cloud_az_double_assign_property,
             },
             fault_space: four_link_faults,
+            support: mini_cloud_az_double_assign_support,
         },
         CorpusScenario {
             name: "mini-cloud-instance-flap",
@@ -235,6 +258,7 @@ pub fn corpus_v2_scenarios() -> Vec<CorpusScenario> {
                 property: cloud_instance_flap_property,
             },
             fault_space: appender_chain_faults,
+            support: mini_cloud_instance_flap_support,
         },
         CorpusScenario {
             name: "mini-cloud-config-drift",
@@ -244,6 +268,7 @@ pub fn corpus_v2_scenarios() -> Vec<CorpusScenario> {
                 property: cloud_config_drift_property,
             },
             fault_space: four_link_faults,
+            support: mini_cloud_config_drift_support,
         },
         CorpusScenario {
             name: "mini-cloud-quota-retry-storm",
@@ -253,6 +278,7 @@ pub fn corpus_v2_scenarios() -> Vec<CorpusScenario> {
                 property: cloud_quota_retry_storm_property,
             },
             fault_space: client_server_faults,
+            support: mini_cloud_quota_retry_storm_support,
         },
     ]
 }
@@ -279,6 +305,11 @@ pub fn corpus_scenario(name: &str) -> Option<CorpusScenario> {
 }
 
 impl CorpusScenario {
+    /// Versioned support provider for this scenario's declared model.
+    pub fn support_provider(&self) -> crate::support::StaticSupportProvider {
+        crate::support::StaticSupportProvider::new(1, (self.support)(&Journal::new()))
+    }
+
     /// Run the scenario at `seed` with optional injected faults under the
     /// corpus gate config (Random policy, 4096-step budget).
     pub fn run(&self, seed: [u8; 32], faults: Vec<SimFault>) -> Result<RunResult, RuntimeError> {

--- a/crates/ledger-explorer/src/reference/sims.rs
+++ b/crates/ledger-explorer/src/reference/sims.rs
@@ -665,3 +665,169 @@ pub fn mini_raft() -> (Vec<TaskBuilder>, impl Fn(&Journal) -> bool) {
     ];
     (builders, single_leader_per_term_oracle())
 }
+
+// ---------------------------------------------------------------------------
+// Explicit support models for the corpus fixtures
+//
+// Each model names the entry roles that jointly support the planted
+// violation, using the semantic role described in the fixture doc comment.
+// A model whose mechanism is a pure timing interaction with no clean entry
+// set is declared Opaque: unknown semantics produce heuristic output only.
+// ---------------------------------------------------------------------------
+
+/// mini-zab: the leader's two proposals are jointly required for the split.
+pub fn mini_zab_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        0,
+    ))
+}
+
+/// mini-hdfs: the NameNode's two grants are jointly required.
+pub fn mini_hdfs_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        0,
+    ))
+}
+
+/// mini-cassandra: the primary's gossip send plus the stale reader's recv
+/// jointly support the anti-entropy staleness.
+pub fn mini_cassandra_support(journal: &Journal) -> crate::support::SupportExpr {
+    let mut ids = crate::support::entry_ids_by(journal, ledger_format::EntryKind::Send, 0);
+    ids.extend(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Recv,
+        2,
+    ));
+    crate::support::all_of_ids(ids)
+}
+
+/// mini-2pc: the coordinator's PREPARE and COMMIT sends are jointly required
+/// for the crash-after-commit violation.
+pub fn mini_2pc_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        0,
+    ))
+}
+
+/// mini-leader-stepdown: both leaders' replication streams jointly support
+/// the stale read after the leadership change.
+pub fn mini_leader_stepdown_support(journal: &Journal) -> crate::support::SupportExpr {
+    let mut ids = crate::support::entry_ids_by(journal, ledger_format::EntryKind::Send, 0);
+    ids.extend(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        2,
+    ));
+    crate::support::all_of_ids(ids)
+}
+
+/// mini-membership-churn: the leader's replication sends are jointly
+/// required for the commit-index stall.
+pub fn mini_membership_churn_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        0,
+    ))
+}
+
+/// mini-hdfs-lease-expiry: the NameNode grant and the stale writer's sends
+/// jointly support the post-expiry write.
+pub fn mini_hdfs_lease_expiry_support(journal: &Journal) -> crate::support::SupportExpr {
+    let mut ids = crate::support::entry_ids_by(journal, ledger_format::EntryKind::Send, 0);
+    ids.extend(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        1,
+    ));
+    crate::support::all_of_ids(ids)
+}
+
+/// mini-reorder-lost-update: both writers' sends are jointly required for
+/// the reordered lost update.
+pub fn mini_reorder_lost_update_support(journal: &Journal) -> crate::support::SupportExpr {
+    let mut ids = crate::support::entry_ids_by(journal, ledger_format::EntryKind::Send, 1);
+    ids.extend(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        2,
+    ));
+    crate::support::all_of_ids(ids)
+}
+
+/// mini-lease-timer-race: a pure timing interaction; no clean entry set.
+pub fn mini_lease_timer_race_support(_journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::SupportExpr::Opaque
+}
+
+/// mini-restart-dup-append: the appender's sends to the durable log are
+/// jointly required for the duplicate append.
+pub fn mini_restart_dup_append_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        1,
+    ))
+}
+
+/// mini-partition-retry-dup: the client's request sends are jointly required
+/// for the duplicate delivery under the partition.
+pub fn mini_partition_retry_dup_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        0,
+    ))
+}
+
+/// mini-cloud-az-double-assign: the scheduler's two assignments are jointly
+/// required for the missing AZ fence.
+pub fn mini_cloud_az_double_assign_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        0,
+    ))
+}
+
+/// mini-cloud-instance-flap: the autoscaler's forwarded registration is
+/// required for the duplicate registration.
+pub fn mini_cloud_instance_flap_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        1,
+    ))
+}
+
+/// mini-cloud-config-drift: the coordinator's pushes are jointly required
+/// for the staged-rollout divergence.
+pub fn mini_cloud_config_drift_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        0,
+    ))
+}
+
+/// mini-cloud-quota-retry-storm: the quota service's apply sends are
+/// required for the backpressure duplicate apply.
+pub fn mini_cloud_quota_retry_storm_support(journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::all_of_ids(crate::support::entry_ids_by(
+        journal,
+        ledger_format::EntryKind::Send,
+        1,
+    ))
+}
+
+/// mini-kv-stale-read: schedule-dependent stale read with no clean entry
+/// set in the shared Mini-Kv workload; declared Opaque.
+pub fn mini_kv_stale_read_support(_journal: &Journal) -> crate::support::SupportExpr {
+    crate::support::SupportExpr::Opaque
+}

--- a/crates/ledger-explorer/src/reference/tests.rs
+++ b/crates/ledger-explorer/src/reference/tests.rs
@@ -39,6 +39,52 @@ fn corpus_scenarios_all_reproduce_and_violate() {
 }
 
 #[test]
+fn every_scenario_exposes_an_explicit_support_model() {
+    let scenarios = all_corpus_scenarios();
+    assert_eq!(
+        scenarios.len(),
+        16,
+        "v1 plus v2 registry holds 16 scenarios"
+    );
+    for scenario in &scenarios {
+        let provider = scenario.support_provider();
+        assert!(
+            provider.version() >= 1,
+            "{}: the support provider must carry a version",
+            scenario.name
+        );
+        let expression = provider.expression();
+        // Every model is one of the three explicit forms; construction
+        // rejects empty sets, so any AllOf or AnyOf here is non-empty.
+        match expression {
+            crate::support::SupportExpr::AllOf(ids) => {
+                assert!(
+                    !ids.is_empty(),
+                    "{}: AllOf must be non-empty",
+                    scenario.name
+                );
+            }
+            crate::support::SupportExpr::AnyOf(branches) => {
+                assert!(
+                    !branches.is_empty(),
+                    "{}: AnyOf must be non-empty",
+                    scenario.name
+                );
+            }
+            crate::support::SupportExpr::Opaque => {}
+        }
+        // The provider digest is stable for the same model.
+        let again = scenario.support_provider();
+        assert_eq!(
+            provider.digest(),
+            again.digest(),
+            "{}: the provider digest must be deterministic",
+            scenario.name
+        );
+    }
+}
+
+#[test]
 fn mini_raft_double_leader_fires_for_some_seed() {
     let mut found: Option<u8> = None;
     let mut holds_for_seed = Vec::new();

--- a/crates/ledger-explorer/src/solver/config.rs
+++ b/crates/ledger-explorer/src/solver/config.rs
@@ -67,6 +67,11 @@ pub fn cutoff() -> usize {
 /// cache keys and the solver-state fingerprint so artifacts from different
 /// run configs never satisfy each other. `None` keeps callers that do not
 /// run a simulation on the historical key space.
+///
+/// `support_version` and `support_digest` pin the support-provider
+/// semantics (see [`crate::support`]). A provider change must never reuse
+/// clauses or hypotheses derived under an older model, so both values join
+/// the cache keys and the solver-state fingerprint.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SolverConfig {
     pub max_horizon: Option<usize>,
@@ -75,6 +80,8 @@ pub struct SolverConfig {
     pub max_faults: Option<usize>,
     pub engine: SolverEngine,
     pub run_config_hash: Option<Hash>,
+    pub support_version: Option<u64>,
+    pub support_digest: Option<Hash>,
 }
 
 impl SolverConfig {
@@ -109,6 +116,18 @@ impl SolverConfig {
 
     pub fn with_run_config_hash(mut self, hash: Hash) -> Self {
         self.run_config_hash = Some(hash);
+        self
+    }
+
+    /// Pin the support-provider version on this config.
+    pub fn with_support_version(mut self, version: u64) -> Self {
+        self.support_version = Some(version);
+        self
+    }
+
+    /// Pin the support-provider digest on this config.
+    pub fn with_support_digest(mut self, digest: Hash) -> Self {
+        self.support_digest = Some(digest);
         self
     }
 }

--- a/crates/ledger-explorer/src/solver/hitting_set.rs
+++ b/crates/ledger-explorer/src/solver/hitting_set.rs
@@ -101,15 +101,7 @@ impl HittingSetSolver {
     /// canonical run-config hash and the max-faults bound, so every encoding
     /// input the solver consumes separates the cache namespace.
     pub(crate) fn incremental_key_with_tag(&self, closure_hash: Hash, engine_tag: u8) -> Hash {
-        ClauseCache::compute_key(
-            closure_hash,
-            self.config.max_horizon,
-            self.config.oracle_version,
-            self.config.input_class,
-            self.config.max_faults,
-            engine_tag,
-            self.config.run_config_hash,
-        )
+        ClauseCache::compute_key(closure_hash, engine_tag, &self.config)
     }
 
     pub(crate) fn clause_cache(&self) -> &ClauseCache {

--- a/crates/ledger-explorer/src/solver/tests.rs
+++ b/crates/ledger-explorer/src/solver/tests.rs
@@ -406,21 +406,17 @@ fn solver_config_input_class_partitions_cache() {
     // Different input classes must not share cache entry (keys differ).
     let ka = ClauseCache::compute_key(
         closure,
-        Some(64),
-        None,
-        Some(crate::pbt::gen_id("alpha")),
-        None,
         crate::solver_cache::engine_tag::BUILTIN,
-        None,
+        &crate::solver::SolverConfig::default()
+            .with_horizon(64)
+            .with_input_class(crate::pbt::gen_id("alpha")),
     );
     let kb = ClauseCache::compute_key(
         closure,
-        Some(64),
-        None,
-        Some(crate::pbt::gen_id("beta")),
-        None,
         crate::solver_cache::engine_tag::BUILTIN,
-        None,
+        &crate::solver::SolverConfig::default()
+            .with_horizon(64)
+            .with_input_class(crate::pbt::gen_id("beta")),
     );
     assert_ne!(ka, kb);
     assert_eq!(key_a, key_b);

--- a/crates/ledger-explorer/src/solver_cache.rs
+++ b/crates/ledger-explorer/src/solver_cache.rs
@@ -8,6 +8,7 @@
 //! instance cache is the primary store; a global [`OnceLock`] store is
 //! provided for cross-solver memoization.
 
+use crate::solver::SolverConfig;
 use ledger_format::Hash;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
@@ -129,51 +130,39 @@ impl ClauseCache {
     /// Compute the content-addressed key for a solver invocation.
     ///
     /// `closure_hash` is `BLAKE3(sorted event ids in the causal closure)`.
-    /// `max_horizon` is the optional derivation depth bound.
-    /// `oracle_version` is the predicate version from `predicate_version`,
-    /// with an explicit presence byte so `None` and `Some(0)` never collapse
-    /// into one key.
-    /// `input_class` partitions the cache per PBT generator stream.
-    /// `max_faults` is the cardinality bound consumed by hazard encodings.
     /// `engine_tag` separates entries per solver engine
     /// ([`engine_tag::BUILTIN`] / [`engine_tag::CADICAL`]); an entry derived
     /// by one engine must never satisfy another.
-    /// `run_config_hash` is the canonical `RunConfig` hash of the encoding's
-    /// simulation context; entries derived under different run configs must
-    /// never satisfy each other.
-    pub fn compute_key(
-        closure_hash: Hash,
-        max_horizon: Option<usize>,
-        oracle_version: Option<u64>,
-        input_class: Option<u64>,
-        max_faults: Option<usize>,
-        engine_tag: u8,
-        run_config_hash: Option<Hash>,
-    ) -> Hash {
+    /// `config` carries the remaining cache dimensions: horizon,
+    /// oracle version, input class, max faults, run-config hash, and the
+    /// support-provider version and digest. Entries derived under different
+    /// values of any dimension must never satisfy each other, and each
+    /// presence byte keeps `None` apart from `Some(0)`.
+    pub fn compute_key(closure_hash: Hash, engine_tag: u8, config: &SolverConfig) -> Hash {
         let mut hasher = blake3::Hasher::new();
         hasher.update(&closure_hash);
         hasher.update(&[0xfe]);
-        if let Some(h) = max_horizon {
+        if let Some(h) = config.max_horizon {
             hasher.update(&(h as u64).to_le_bytes());
         } else {
             hasher.update(&[0xff, 0xff]);
         }
         hasher.update(&[0xfd]);
-        if let Some(version) = oracle_version {
+        if let Some(version) = config.oracle_version {
             hasher.update(&[0x01]);
             hasher.update(&version.to_le_bytes());
         } else {
             hasher.update(&[0x00]);
         }
         hasher.update(&[0xfc]);
-        if let Some(class) = input_class {
+        if let Some(class) = config.input_class {
             hasher.update(&[0x01]);
             hasher.update(&class.to_le_bytes());
         } else {
             hasher.update(&[0x00]);
         }
         hasher.update(&[0xfb]);
-        if let Some(faults) = max_faults {
+        if let Some(faults) = config.max_faults {
             hasher.update(&[0x01]);
             hasher.update(&(faults as u64).to_le_bytes());
         } else {
@@ -182,9 +171,23 @@ impl ClauseCache {
         hasher.update(&[0xfa]);
         hasher.update(&[engine_tag]);
         hasher.update(&[0xf9]);
-        if let Some(hash) = run_config_hash {
+        if let Some(hash) = config.run_config_hash {
             hasher.update(&[0x01]);
             hasher.update(&hash);
+        } else {
+            hasher.update(&[0x00]);
+        }
+        hasher.update(&[0xf8]);
+        if let Some(version) = config.support_version {
+            hasher.update(&[0x01]);
+            hasher.update(&version.to_le_bytes());
+        } else {
+            hasher.update(&[0x00]);
+        }
+        hasher.update(&[0xf7]);
+        if let Some(digest) = config.support_digest {
+            hasher.update(&[0x01]);
+            hasher.update(&digest);
         } else {
             hasher.update(&[0x00]);
         }
@@ -265,24 +268,15 @@ mod tests {
         let closure = hash_of(7);
         let k1 = ClauseCache::compute_key(
             closure,
-            Some(10),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(10),
         );
         let k2 = ClauseCache::compute_key(
             closure,
-            Some(100),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(100),
         );
-        let k3 =
-            ClauseCache::compute_key(closure, None, None, None, None, engine_tag::BUILTIN, None);
+        let k3 = ClauseCache::compute_key(closure, engine_tag::BUILTIN, &SolverConfig::default());
         assert_ne!(k1, k2);
         assert_ne!(k1, k3);
     }
@@ -292,21 +286,13 @@ mod tests {
         let closure = hash_of(9);
         let k1 = ClauseCache::compute_key(
             closure,
-            None,
-            Some(1),
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_oracle_version(1),
         );
         let k2 = ClauseCache::compute_key(
             closure,
-            None,
-            Some(2),
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_oracle_version(2),
         );
         assert_ne!(k1, k2);
     }
@@ -317,28 +303,64 @@ mod tests {
         // configurations: the presence byte must keep them apart, mirroring
         // the state fingerprint's None-vs-Some(0) behavior.
         let closure = hash_of(9);
-        let none =
-            ClauseCache::compute_key(closure, None, None, None, None, engine_tag::BUILTIN, None);
+        let none = ClauseCache::compute_key(closure, engine_tag::BUILTIN, &SolverConfig::default());
         let zero = ClauseCache::compute_key(
             closure,
-            None,
-            Some(0),
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_oracle_version(0),
         );
         assert_ne!(none, zero);
         let again = ClauseCache::compute_key(
             closure,
-            None,
-            Some(0),
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_oracle_version(0),
         );
         assert_eq!(zero, again);
+    }
+
+    #[test]
+    fn compute_key_differs_on_support_version() {
+        // A provider version change must isolate the cache: same closure,
+        // horizon, oracle, and run config, different support version.
+        let closure = hash_of(11);
+        let digest = hash_of(3);
+        let v1 = ClauseCache::compute_key(
+            closure,
+            engine_tag::BUILTIN,
+            &SolverConfig::default()
+                .with_support_version(1)
+                .with_support_digest(digest),
+        );
+        let v2 = ClauseCache::compute_key(
+            closure,
+            engine_tag::BUILTIN,
+            &SolverConfig::default()
+                .with_support_version(2)
+                .with_support_digest(digest),
+        );
+        assert_ne!(v1, v2);
+    }
+
+    #[test]
+    fn compute_key_differs_on_support_digest() {
+        // A provider model change must isolate the cache even when the
+        // version is unchanged: different digest, all else equal.
+        let closure = hash_of(13);
+        let a = ClauseCache::compute_key(
+            closure,
+            engine_tag::BUILTIN,
+            &SolverConfig::default()
+                .with_support_version(1)
+                .with_support_digest(hash_of(1)),
+        );
+        let b = ClauseCache::compute_key(
+            closure,
+            engine_tag::BUILTIN,
+            &SolverConfig::default()
+                .with_support_version(1)
+                .with_support_digest(hash_of(2)),
+        );
+        assert_ne!(a, b);
     }
 
     #[test]
@@ -346,30 +368,18 @@ mod tests {
         let closure = hash_of(7);
         let k_none = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64),
         );
         let k_a = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            Some(1),
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64).with_input_class(1),
         );
         let k_b = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            Some(2),
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64).with_input_class(2),
         );
         assert_ne!(k_none, k_a);
         assert_ne!(k_a, k_b);
@@ -380,21 +390,13 @@ mod tests {
         let closure = hash_of(7);
         let k1 = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64),
         );
         let k2 = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64),
         );
         assert_eq!(k1, k2);
     }
@@ -406,21 +408,13 @@ mod tests {
         let closure = hash_of(7);
         let builtin = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64),
         );
         let cadical = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::CADICAL,
-            None,
+            &SolverConfig::default().with_horizon(64),
         );
         assert_ne!(builtin, cadical);
     }
@@ -430,30 +424,18 @@ mod tests {
         let closure = hash_of(7);
         let none = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64),
         );
         let bounded = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            Some(2),
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64).with_max_faults(2),
         );
         let bounded_more = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            Some(3),
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64).with_max_faults(3),
         );
         assert_ne!(none, bounded);
         assert_ne!(bounded, bounded_more);
@@ -466,30 +448,22 @@ mod tests {
         let closure = hash_of(7);
         let none = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            None,
+            &SolverConfig::default().with_horizon(64),
         );
         let run_a = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            Some(hash_of(1)),
+            &SolverConfig::default()
+                .with_horizon(64)
+                .with_run_config_hash(hash_of(1)),
         );
         let run_b = ClauseCache::compute_key(
             closure,
-            Some(64),
-            None,
-            None,
-            None,
             engine_tag::BUILTIN,
-            Some(hash_of(2)),
+            &SolverConfig::default()
+                .with_horizon(64)
+                .with_run_config_hash(hash_of(2)),
         );
         assert_ne!(none, run_a);
         assert_ne!(run_a, run_b);

--- a/crates/ledger-explorer/src/solver_state.rs
+++ b/crates/ledger-explorer/src/solver_state.rs
@@ -272,6 +272,26 @@ pub fn fingerprint(config: &SolverConfig, resolved_engine: SolverEngine) -> Hash
             hasher.update(&[0x00]);
         }
     }
+    hasher.update(&[0x07]);
+    match config.support_version {
+        Some(value) => {
+            hasher.update(&[0x01]);
+            hasher.update(&value.to_le_bytes());
+        }
+        None => {
+            hasher.update(&[0x00]);
+        }
+    }
+    hasher.update(&[0x08]);
+    match config.support_digest {
+        Some(digest) => {
+            hasher.update(&[0x01]);
+            hasher.update(&digest);
+        }
+        None => {
+            hasher.update(&[0x00]);
+        }
+    }
     *hasher.finalize().as_bytes()
 }
 
@@ -830,6 +850,8 @@ mod tests {
             max_faults: None,
             engine: SolverEngine::Auto,
             run_config_hash: None,
+            support_version: None,
+            support_digest: None,
         };
         assert_eq!(
             fingerprint(&literal, SolverEngine::Builtin),
@@ -1428,6 +1450,8 @@ mod tests {
             max_faults: None,
             engine: SolverEngine::Auto,
             run_config_hash: None,
+            support_version: None,
+            support_digest: None,
         };
         let zero_horizon = SolverConfig {
             max_horizon: Some(0),
@@ -1436,6 +1460,8 @@ mod tests {
             max_faults: Some(0),
             engine: SolverEngine::Auto,
             run_config_hash: None,
+            support_version: None,
+            support_digest: None,
         };
         assert_ne!(
             fingerprint(&none_horizon, SolverEngine::Builtin),
@@ -1453,6 +1479,43 @@ mod tests {
         assert_ne!(
             fingerprint(&with_horizon_none, SolverEngine::Builtin),
             fingerprint(&with_horizon_zero, SolverEngine::Builtin)
+        );
+    }
+
+    #[test]
+    fn fingerprint_isolates_support_provider() {
+        let digest_a = test_hash(1);
+        let digest_b = test_hash(2);
+        let base = SolverConfig {
+            support_version: Some(1),
+            support_digest: Some(digest_a),
+            ..Default::default()
+        };
+        let other_version = SolverConfig {
+            support_version: Some(2),
+            support_digest: Some(digest_a),
+            ..Default::default()
+        };
+        let other_digest = SolverConfig {
+            support_version: Some(1),
+            support_digest: Some(digest_b),
+            ..Default::default()
+        };
+        let no_support = SolverConfig::default();
+        assert_ne!(
+            fingerprint(&base, SolverEngine::Builtin),
+            fingerprint(&other_version, SolverEngine::Builtin),
+            "provider version change must isolate the state fingerprint"
+        );
+        assert_ne!(
+            fingerprint(&base, SolverEngine::Builtin),
+            fingerprint(&other_digest, SolverEngine::Builtin),
+            "provider model change must isolate the state fingerprint"
+        );
+        assert_ne!(
+            fingerprint(&base, SolverEngine::Builtin),
+            fingerprint(&no_support, SolverEngine::Builtin),
+            "an absent provider must not collide with a pinned one"
         );
     }
 

--- a/crates/ledger-explorer/src/support.rs
+++ b/crates/ledger-explorer/src/support.rs
@@ -1,0 +1,491 @@
+//! Typed support semantics for fault-cut evidence.
+//!
+//! Journal parent edges represent causal order only. They never imply that a
+//! parent is sufficient or necessary support for an outcome. Support is
+//! declared explicitly by a [`SupportProvider`]; no code path in this module
+//! infers support from parent count, path shape, or vector-clock order.
+//!
+//! The [`SupportExpr`] tree is the single source of support semantics. An
+//! expression with any [`SupportExpr::Opaque`] child cannot back strong
+//! fault-cut or optimality claims ([`SupportExpr::is_strong`] reports that).
+
+use std::collections::BTreeSet;
+
+use ledger_format::{ActorId, EntryKind, Hash};
+use ledger_journal::Journal;
+use thiserror::Error;
+
+/// Typed failure while constructing a support expression.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SupportError {
+    /// An `AllOf` expression must name at least one jointly required entry.
+    #[error("AllOf requires at least one jointly required entry")]
+    EmptyAllOf,
+    /// An `AnyOf` expression must list at least one alternative branch.
+    #[error("AnyOf requires at least one alternative branch")]
+    EmptyAnyOf,
+}
+
+/// Result of evaluating a support expression against a journal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupportOutcome {
+    /// Every `AllOf` child exists and at least one `AnyOf` branch holds.
+    Satisfied,
+    /// The expression evaluates to false against the journal.
+    NotSatisfied,
+    /// `Opaque` semantics or a horizon cut leave the truth unknown.
+    Unknown,
+}
+
+impl SupportOutcome {
+    /// Whether the outcome is a definite positive.
+    pub fn is_satisfied(self) -> bool {
+        matches!(self, Self::Satisfied)
+    }
+}
+
+/// Explicit support expression over journal entry ids.
+///
+/// `AllOf` means every child is jointly required. `AnyOf` means one listed
+/// branch is sufficient. `Opaque` prevents strong fault-cut and optimality
+/// claims: any `Opaque` child forces [`SupportExpr::is_strong`] to `false`.
+///
+/// The variants are public for pattern matching, but construction goes
+/// through [`SupportExpr::all_of`] and [`SupportExpr::any_of`] (or the
+/// `TryFrom` impls) so an empty `AllOf` or `AnyOf` cannot be built.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SupportExpr {
+    /// Every listed entry is jointly required.
+    AllOf(BTreeSet<Hash>),
+    /// One listed branch is sufficient.
+    AnyOf(Vec<SupportExpr>),
+    /// Semantics are unknown; strong claims degrade to heuristic.
+    Opaque,
+}
+
+impl SupportExpr {
+    /// Construct `AllOf`, rejecting an empty requirement set.
+    pub fn all_of(ids: BTreeSet<Hash>) -> Result<Self, SupportError> {
+        if ids.is_empty() {
+            return Err(SupportError::EmptyAllOf);
+        }
+        Ok(Self::AllOf(ids))
+    }
+
+    /// Construct `AnyOf`, rejecting an empty branch list.
+    pub fn any_of(branches: Vec<SupportExpr>) -> Result<Self, SupportError> {
+        if branches.is_empty() {
+            return Err(SupportError::EmptyAnyOf);
+        }
+        Ok(Self::AnyOf(branches))
+    }
+
+    /// Whether this expression supports strong fault-cut and optimality
+    /// claims. Any `Opaque` child degrades the whole expression to heuristic.
+    pub fn is_strong(&self) -> bool {
+        match self {
+            Self::AllOf(_) => true,
+            Self::AnyOf(branches) => branches.iter().all(SupportExpr::is_strong),
+            Self::Opaque => false,
+        }
+    }
+
+    /// Evaluate this expression against `journal`.
+    pub fn evaluate(&self, journal: &Journal) -> SupportOutcome {
+        self.evaluate_with_horizon(journal, None)
+    }
+
+    /// Evaluate with an optional derivation-depth horizon.
+    ///
+    /// Nested `AnyOf` branches beyond the horizon evaluate to
+    /// [`SupportOutcome::Unknown`], so a bounded walk cannot over-claim.
+    pub fn evaluate_with_horizon(
+        &self,
+        journal: &Journal,
+        horizon: Option<usize>,
+    ) -> SupportOutcome {
+        self.eval_depth(journal, horizon, 0)
+    }
+
+    fn eval_depth(
+        &self,
+        journal: &Journal,
+        horizon: Option<usize>,
+        depth: usize,
+    ) -> SupportOutcome {
+        if let Some(limit) = horizon
+            && depth > limit
+        {
+            return SupportOutcome::Unknown;
+        }
+        match self {
+            Self::Opaque => SupportOutcome::Unknown,
+            Self::AllOf(ids) => {
+                if ids.iter().all(|id| journal.get(id).is_some()) {
+                    SupportOutcome::Satisfied
+                } else {
+                    SupportOutcome::NotSatisfied
+                }
+            }
+            Self::AnyOf(branches) => {
+                let mut saw_unknown = false;
+                for branch in branches {
+                    match branch.eval_depth(journal, horizon, depth + 1) {
+                        SupportOutcome::Satisfied => return SupportOutcome::Satisfied,
+                        SupportOutcome::Unknown => saw_unknown = true,
+                        SupportOutcome::NotSatisfied => {}
+                    }
+                }
+                if saw_unknown {
+                    SupportOutcome::Unknown
+                } else {
+                    SupportOutcome::NotSatisfied
+                }
+            }
+        }
+    }
+
+    /// Canonical encoding: a variant tag byte followed by sorted child bytes.
+    ///
+    /// `BTreeSet` iteration and the recursive visit order are deterministic,
+    /// so equal expressions always encode to equal bytes.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        self.encode_into(&mut out);
+        out
+    }
+
+    fn encode_into(&self, out: &mut Vec<u8>) {
+        match self {
+            Self::AllOf(ids) => {
+                out.push(0x00);
+                for id in ids {
+                    out.extend_from_slice(id);
+                }
+            }
+            Self::AnyOf(branches) => {
+                out.push(0x01);
+                for branch in branches {
+                    branch.encode_into(out);
+                }
+            }
+            Self::Opaque => out.push(0x02),
+        }
+    }
+
+    /// BLAKE3 digest over the canonical encoding.
+    pub fn digest(&self) -> Hash {
+        *blake3::hash(&self.canonical_bytes()).as_bytes()
+    }
+}
+
+impl TryFrom<BTreeSet<Hash>> for SupportExpr {
+    type Error = SupportError;
+
+    fn try_from(ids: BTreeSet<Hash>) -> Result<Self, Self::Error> {
+        Self::all_of(ids)
+    }
+}
+
+impl TryFrom<Vec<SupportExpr>> for SupportExpr {
+    type Error = SupportError;
+
+    fn try_from(branches: Vec<SupportExpr>) -> Result<Self, Self::Error> {
+        Self::any_of(branches)
+    }
+}
+
+/// Versioned support provider.
+///
+/// Derives support from workload, effect, oracle, or adapter semantics.
+/// [`SupportProvider::version`] and [`SupportProvider::digest`] identify the
+/// provider; both feed solver cache keys so a provider change never reuses
+/// derived clauses or hypotheses.
+pub trait SupportProvider {
+    /// Provider version. Bump when the derived semantics change.
+    fn version(&self) -> u64;
+
+    /// Digest over `version` and the declared expression.
+    fn digest(&self) -> Hash;
+
+    /// The support expression this provider derives for `journal`.
+    fn support(&self, journal: &Journal) -> SupportExpr;
+}
+
+/// Provider that serves one explicitly declared expression.
+///
+/// The fixture registry uses this type to attach a versioned, digest-pinned
+/// support model to every certifiable corpus scenario.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaticSupportProvider {
+    version: u64,
+    expression: SupportExpr,
+    digest: Hash,
+}
+
+impl StaticSupportProvider {
+    /// Construct a provider whose digest pins `version` and `expression`.
+    pub fn new(version: u64, expression: SupportExpr) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&version.to_le_bytes());
+        hasher.update(&expression.digest());
+        let digest = *hasher.finalize().as_bytes();
+        Self {
+            version,
+            expression,
+            digest,
+        }
+    }
+
+    /// The declared expression this provider serves.
+    pub fn expression(&self) -> &SupportExpr {
+        &self.expression
+    }
+
+    /// The provider version.
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// The provider digest over `version` and the declared expression.
+    pub fn digest(&self) -> Hash {
+        self.digest
+    }
+}
+
+impl SupportProvider for StaticSupportProvider {
+    fn version(&self) -> u64 {
+        self.version
+    }
+
+    fn digest(&self) -> Hash {
+        self.digest
+    }
+
+    fn support(&self, _journal: &Journal) -> SupportExpr {
+        self.expression.clone()
+    }
+}
+
+/// Collect every entry id of `kind` written by `actor`.
+///
+/// The result is a `BTreeSet`, so ids arrive canonically sorted for
+/// [`SupportExpr::all_of`].
+pub fn entry_ids_by(journal: &Journal, kind: EntryKind, actor: ActorId) -> BTreeSet<Hash> {
+    journal
+        .entries()
+        .filter(|entry| entry.data.kind == kind && entry.data.actor == actor)
+        .map(|entry| entry.id)
+        .collect()
+}
+
+/// Build `AllOf` over `ids`, degrading to `Opaque` when the set is empty.
+///
+/// A run without the named semantic role cannot support a strong claim, so
+/// the model reports unknown instead of an empty requirement set.
+pub fn all_of_ids(ids: impl IntoIterator<Item = Hash>) -> SupportExpr {
+    match SupportExpr::all_of(ids.into_iter().collect()) {
+        Ok(expr) => expr,
+        Err(_) => SupportExpr::Opaque,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ledger_format::Payload;
+
+    fn journal_with_ids(count: usize) -> (Journal, Vec<Hash>) {
+        let mut journal = Journal::new();
+        let mut recorded = Vec::new();
+        for i in 0..count {
+            let hash = journal
+                .append(
+                    EntryKind::Send,
+                    (i % 3) as ActorId,
+                    [],
+                    Payload::Number(i as u64),
+                )
+                .expect("append must succeed");
+            recorded.push(hash);
+        }
+        (journal, recorded)
+    }
+
+    fn absent_id() -> Hash {
+        [0xEE; 32]
+    }
+
+    fn all(ids: Vec<Hash>) -> SupportExpr {
+        SupportExpr::all_of(ids.into_iter().collect()).expect("non-empty")
+    }
+
+    fn any(branches: Vec<SupportExpr>) -> SupportExpr {
+        SupportExpr::any_of(branches).expect("non-empty")
+    }
+
+    #[test]
+    fn construction_rejects_empty_all_of() {
+        assert_eq!(
+            SupportExpr::all_of(BTreeSet::new()),
+            Err(SupportError::EmptyAllOf)
+        );
+        assert_eq!(
+            BTreeSet::<Hash>::new().try_into(),
+            Err::<SupportExpr, _>(SupportError::EmptyAllOf)
+        );
+    }
+
+    #[test]
+    fn construction_rejects_empty_any_of() {
+        assert_eq!(
+            SupportExpr::any_of(Vec::new()),
+            Err(SupportError::EmptyAnyOf)
+        );
+        assert_eq!(
+            Vec::<SupportExpr>::new().try_into(),
+            Err::<SupportExpr, _>(SupportError::EmptyAnyOf)
+        );
+    }
+
+    #[test]
+    fn nested_truth_table_satisfied_cases() {
+        let (journal, recorded) = journal_with_ids(4);
+        let (a, b, c, d) = (recorded[0], recorded[1], recorded[2], recorded[3]);
+
+        // AllOf over present ids: satisfied.
+        assert_eq!(
+            all(vec![a, b]).evaluate(&journal),
+            SupportOutcome::Satisfied
+        );
+        // Nested AnyOf{AllOf{a,b}, AllOf{c,d}} with both branches present.
+        let nested = any(vec![all(vec![a, b]), all(vec![c, d])]);
+        assert_eq!(nested.evaluate(&journal), SupportOutcome::Satisfied);
+    }
+
+    #[test]
+    fn all_of_requires_every_child() {
+        let (journal, recorded) = journal_with_ids(2);
+        let (present, missing) = (recorded[0], absent_id());
+        assert_eq!(
+            all(vec![present, missing]).evaluate(&journal),
+            SupportOutcome::NotSatisfied
+        );
+    }
+
+    #[test]
+    fn any_of_one_branch_suffices() {
+        let (journal, recorded) = journal_with_ids(1);
+        let (present, absent) = (recorded[0], absent_id());
+        let expr = any(vec![all(vec![absent]), all(vec![present])]);
+        assert_eq!(expr.evaluate(&journal), SupportOutcome::Satisfied);
+    }
+
+    #[test]
+    fn chain_deeper_than_horizon_is_unknown() {
+        let (journal, recorded) = journal_with_ids(3);
+        let (a, b, c) = (recorded[0], recorded[1], recorded[2]);
+        let chain = any(vec![any(vec![any(vec![all(vec![a, b, c])])])]);
+        assert_eq!(chain.evaluate(&journal), SupportOutcome::Satisfied);
+        assert_eq!(
+            chain.evaluate_with_horizon(&journal, Some(1)),
+            SupportOutcome::Unknown,
+            "a bounded walk cannot verify past its depth"
+        );
+    }
+
+    #[test]
+    fn diamond_holds_when_either_witness_present() {
+        let (journal, recorded) = journal_with_ids(3);
+        let (a, b, c) = (recorded[0], recorded[1], recorded[2]);
+        let diamond = any(vec![all(vec![a, b]), all(vec![a, c])]);
+        assert_eq!(diamond.evaluate(&journal), SupportOutcome::Satisfied);
+    }
+
+    #[test]
+    fn redundant_support_member_is_still_required() {
+        let (journal, recorded) = journal_with_ids(1);
+        let (present, duplicate) = (recorded[0], absent_id());
+        // A redundant member cannot be elided: it is still jointly required.
+        assert_eq!(
+            all(vec![present, duplicate]).evaluate(&journal),
+            SupportOutcome::NotSatisfied
+        );
+    }
+
+    #[test]
+    fn disjoint_witness_only_one_present() {
+        let (journal, recorded) = journal_with_ids(3);
+        let (a, b, c) = (recorded[0], recorded[1], recorded[2]);
+        let missing = absent_id();
+        let disjoint = any(vec![all(vec![a, missing]), all(vec![b, c])]);
+        assert_eq!(disjoint.evaluate(&journal), SupportOutcome::Satisfied);
+    }
+
+    #[test]
+    fn opaque_degrades_strong_claims() {
+        let (journal, recorded) = journal_with_ids(2);
+        let (a, b) = (recorded[0], recorded[1]);
+        let strong = all(vec![a, b]);
+        assert!(strong.is_strong());
+        let with_opaque = any(vec![all(vec![a]), SupportExpr::Opaque]);
+        assert!(!with_opaque.is_strong());
+        assert_eq!(
+            with_opaque.evaluate(&journal),
+            SupportOutcome::Satisfied,
+            "the satisfied branch still satisfies, but the claim is weak"
+        );
+        assert_eq!(
+            SupportExpr::Opaque.evaluate(&journal),
+            SupportOutcome::Unknown
+        );
+    }
+
+    #[test]
+    fn encoding_and_digest_are_equivalent() {
+        let (_journal, recorded) = journal_with_ids(2);
+        let (a, b) = (recorded[0], recorded[1]);
+        let left = all(vec![a, b]);
+        let right = all(vec![a, b]);
+        assert_eq!(left.canonical_bytes(), right.canonical_bytes());
+        assert_eq!(left.digest(), right.digest());
+        // AllOf is a set: member order never changes the expression.
+        assert_eq!(all(vec![a, b]).digest(), all(vec![b, a]).digest());
+        // Same provider state yields the same provider digest.
+        let provider_a = StaticSupportProvider::new(1, left.clone());
+        let provider_b = StaticSupportProvider::new(1, right.clone());
+        assert_eq!(provider_a.digest(), provider_b.digest());
+        assert_eq!(provider_a.version(), 1);
+    }
+
+    #[test]
+    fn provider_digest_changes_with_version() {
+        let (_journal, recorded) = journal_with_ids(1);
+        let expr = all(vec![recorded[0]]);
+        let v1 = StaticSupportProvider::new(1, expr.clone());
+        let v2 = StaticSupportProvider::new(2, expr);
+        assert_ne!(v1.digest(), v2.digest());
+    }
+
+    #[test]
+    fn opaque_has_distinct_canonical_bytes() {
+        assert_eq!(SupportExpr::Opaque.canonical_bytes(), vec![0x02]);
+        let (_journal, recorded) = journal_with_ids(1);
+        assert_eq!(all(vec![recorded[0]]).canonical_bytes()[0], 0x00);
+    }
+
+    #[test]
+    fn entry_ids_by_filters_kind_and_actor() {
+        let mut journal = Journal::new();
+        let send = journal
+            .append(EntryKind::Send, 0, [], Payload::Number(1))
+            .expect("send");
+        journal
+            .append(EntryKind::Recv, 1, [], Payload::Number(2))
+            .expect("recv");
+        let ids = entry_ids_by(&journal, EntryKind::Send, 0);
+        assert_eq!(ids.len(), 1);
+        assert!(ids.contains(&send));
+        assert!(entry_ids_by(&journal, EntryKind::Send, 1).is_empty());
+    }
+}


### PR DESCRIPTION
A1 - typed support semantics: SupportExpr (AllOf/AnyOf/Opaque) with non-empty constructors, a versioned SupportProvider whose digest folds into solver cache keys and the solver-state fingerprint, and explicit support models for every corpus fixture. Journal parent edges no longer masquerade as support.