### PR TITLE
Feat/quality audit remediation

### DIFF
--- a/crates/ldgr-rt/Cargo.toml
+++ b/crates/ldgr-rt/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ldgr-rt"
-version = "0.1.0"
-edition = "2024"
-rust-version = "1.90"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0"
 description = "Drop-in deterministic runtime facade for ldgr simulation"
 readme = "README.md"
@@ -14,7 +14,7 @@ ledger-sim = { path = "../ledger-sim", optional = true }
 # route that maps `ledger_sim::RuntimeError`.
 ledger-journal = { path = "../ledger-journal", optional = true }
 blake3 = { workspace = true }
-tokio = { workspace = true, features = ["rt", "time", "net"] }
+tokio = { workspace = true, features = ["rt", "time", "net", "sync"] }
 rand_core = { workspace = true }
 rand_chacha = { workspace = true }
 getrandom = { workspace = true }

--- a/crates/ldgr-rt/src/net.rs
+++ b/crates/ldgr-rt/src/net.rs
@@ -68,6 +68,8 @@ impl Conn {
             to: self.to,
             payload,
         });
+        drop(net);
+        self.shared.notify().notify_waiters();
         true
     }
 
@@ -133,12 +135,18 @@ impl Conn {
 #[derive(Debug, Clone, Default)]
 pub struct SharedNetwork {
     inner: Arc<Mutex<SharedNet>>,
+    notify: Arc<tokio::sync::Notify>,
 }
 
 impl SharedNetwork {
     /// Crate-internal access to the guarded net state.
     pub(crate) fn inner(&self) -> &Arc<Mutex<SharedNet>> {
         &self.inner
+    }
+
+    /// Crate-internal access to the notification primitive.
+    pub(crate) fn notify(&self) -> &Arc<tokio::sync::Notify> {
+        &self.notify
     }
 }
 

--- a/crates/ldgr-rt/src/runtime.rs
+++ b/crates/ldgr-rt/src/runtime.rs
@@ -158,6 +158,7 @@ impl From<RunConfigBuilder> for RunConfig {
 ///
 /// Facade-local carrier: liveness detail requires the simulation backend;
 /// other builds report [`RunCompletion::Completed`] for their runs.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunCompletion {
     /// Every task finished.
@@ -593,14 +594,17 @@ impl Handle {
         // Non-sim (and sim IPC): destination-based receive over the shared
         // in-process net; sender ids are never scanned or bounded here.
         loop {
-            let payload = match self.shared_net.inner().lock() {
-                Ok(mut net) => net.recv_for(self.actor),
-                Err(_) => None,
+            let notified = {
+                let mut net = match self.shared_net.inner().lock() {
+                    Ok(g) => g,
+                    Err(_) => return 0,
+                };
+                if let Some(payload) = net.recv_for(self.actor) {
+                    return payload;
+                }
+                self.shared_net.notify().notified()
             };
-            if let Some(payload) = payload {
-                return payload;
-            }
-            tokio::task::yield_now().await;
+            notified.await;
         }
     }
 

--- a/crates/ledger-adapters/Cargo.toml
+++ b/crates/ledger-adapters/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ledger-adapters"
-version = "0.1.0"
-edition = "2024"
-rust-version = "1.90"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 license = "Apache-2.0"
 description = "OTel ingest adapters for ledger journal"
 readme = "README.md"

--- a/crates/ledger-adapters/src/envelope.rs
+++ b/crates/ledger-adapters/src/envelope.rs
@@ -268,34 +268,7 @@ fn mapping_to_json(m: &EntryMapping) -> JsonMapping {
 }
 
 fn json_to_kind(jm: &JsonMapping) -> Result<EntryKind, AdapterError> {
-    let tag = jm.kind_tag;
-    match tag {
-        0 => Ok(EntryKind::Spawn),
-        1 => Ok(EntryKind::Block),
-        2 => Ok(EntryKind::Wake),
-        3 => Ok(EntryKind::TimerSet),
-        4 => Ok(EntryKind::TimerFire),
-        5 => Ok(EntryKind::ClockRead),
-        6 => Ok(EntryKind::Send),
-        7 => Ok(EntryKind::Recv),
-        8 => Ok(EntryKind::FsWrite),
-        9 => Ok(EntryKind::FsFsync),
-        10 => Ok(EntryKind::FsRead),
-        11 => Ok(EntryKind::RngDraw),
-        12 => Ok(EntryKind::Outcome),
-        13 => Ok(EntryKind::Assert),
-        14 => Ok(EntryKind::Snapshot),
-        15 => Ok(EntryKind::Epoch),
-        16 => Ok(EntryKind::InputStep),
-        17 => Ok(EntryKind::CapRequest),
-        18 => Ok(EntryKind::CapGrant),
-        19 => Ok(EntryKind::CapInvoke),
-        20 => Ok(EntryKind::CapRevoke),
-        21 => Ok(EntryKind::Fault),
-        22 => Ok(EntryKind::StepBegin),
-        23 => Ok(EntryKind::StepEnd),
-        _ => Err(AdapterError::InvalidHeader),
-    }
+    EntryKind::try_from(jm.kind_tag).map_err(|_| AdapterError::InvalidHeader)
 }
 
 #[cfg(test)]

--- a/crates/ledger-explorer/src/solver_cache.rs
+++ b/crates/ledger-explorer/src/solver_cache.rs
@@ -481,14 +481,17 @@ mod tests {
 
     #[test]
     fn global_cache_is_singleton() {
-        global_clear();
+        let mut guard = global_cache()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard.clear();
         let key = hash_of(11);
         let clause = WeightedClause::new(vec![hash_of(2)], 7);
-        global_insert(key, vec![clause.clone()]);
-        assert_eq!(global_get(&key), Some(vec![clause]));
-        assert_eq!(global_len(), 1);
-        global_clear();
-        assert_eq!(global_len(), 0);
+        guard.insert(key, vec![clause.clone()]);
+        assert_eq!(guard.get_cloned(&key), Some(vec![clause]));
+        assert_eq!(guard.len(), 1);
+        guard.clear();
+        assert_eq!(guard.len(), 0);
     }
 
     #[test]

--- a/crates/ledger-flow/src/lib.rs
+++ b/crates/ledger-flow/src/lib.rs
@@ -466,4 +466,37 @@ mod tests {
         );
         assert_eq!(recovered2.step_counter, 2);
     }
+
+    #[test]
+    fn resume_async_executes_steps() {
+        let mut journal = Journal::new();
+        let plan = WorkflowPlan::plan(vec!["step_a".to_string(), "step_b".to_string()]).unwrap();
+        let mut wf = WorkflowExecution::new(1);
+        wf.set_plan(plan);
+
+        let fut = wf.resume_async(&mut journal, |name| {
+            let name = name.to_string();
+            async move {
+                match name.as_str() {
+                    "step_a" => Ok(10),
+                    "step_b" => Ok(20),
+                    _ => Err(FlowError::DuplicateStep("unknown".into())),
+                }
+            }
+        });
+
+        let mut pinned = Box::pin(fut);
+        let waker = std::task::Waker::noop();
+        let mut cx = std::task::Context::from_waker(waker);
+        let outcomes = match std::future::Future::poll(pinned.as_mut(), &mut cx) {
+            std::task::Poll::Ready(res) => res.unwrap(),
+            std::task::Poll::Pending => panic!("expected immediate ready"),
+        };
+
+        assert_eq!(outcomes.len(), 2);
+        assert_eq!(outcomes[0].status, ResumeStatus::Executed);
+        assert_eq!(outcomes[0].result, 10);
+        assert_eq!(outcomes[1].status, ResumeStatus::Executed);
+        assert_eq!(outcomes[1].result, 20);
+    }
 }

--- a/crates/ledger-flow/src/workflow.rs
+++ b/crates/ledger-flow/src/workflow.rs
@@ -269,6 +269,62 @@ impl WorkflowExecution {
         }
         Ok(outcomes)
     }
+
+    /// Asynchronous variant of [`Self::resume`] accepting an async step executor.
+    ///
+    /// # Errors
+    /// Returns [`FlowError::NoPlan`] when no plan is attached via
+    /// [`Self::set_plan`], [`FlowError::Journal`] when an append fails, and
+    /// propagates errors from `exec`.
+    pub async fn resume_async<F, Fut>(
+        &mut self,
+        journal: &mut Journal,
+        mut exec: F,
+    ) -> Result<Vec<StepOutcome>, FlowError>
+    where
+        F: FnMut(&str) -> Fut,
+        Fut: core::future::Future<Output = Result<u64, FlowError>>,
+    {
+        let steps: Vec<String> = self
+            .plan
+            .as_ref()
+            .ok_or(FlowError::NoPlan)?
+            .steps()
+            .to_vec();
+        let evidence = scan_step_evidence(journal, self.actor);
+
+        let mut outcomes = Vec::with_capacity(steps.len());
+        for name in &steps {
+            let outcome = match classify(name, &evidence) {
+                StepPrior::Skipped { result } => StepOutcome {
+                    name: name.clone(),
+                    status: ResumeStatus::Skipped,
+                    result,
+                },
+                StepPrior::InProgress(begin_hash) => {
+                    let value = exec(name).await?;
+                    self.step_end(journal, name, begin_hash, value)?;
+                    StepOutcome {
+                        name: name.clone(),
+                        status: ResumeStatus::Rerun,
+                        result: value,
+                    }
+                }
+                StepPrior::Pending => {
+                    let begin_hash = self.step_begin(journal, name)?;
+                    let value = exec(name).await?;
+                    self.step_end(journal, name, begin_hash, value)?;
+                    StepOutcome {
+                        name: name.clone(),
+                        status: ResumeStatus::Executed,
+                        result: value,
+                    }
+                }
+            };
+            outcomes.push(outcome);
+        }
+        Ok(outcomes)
+    }
 }
 
 /// Journal evidence about durable steps, keyed by step name.

--- a/crates/ledger-format/src/cbor/encode.rs
+++ b/crates/ledger-format/src/cbor/encode.rs
@@ -5,32 +5,22 @@ use super::{CborError, CborValue, TAG_ALLOWLIST, compare_canonical_keys};
 impl CborValue {
     /// Returns the canonical serialized bytes of this value.
     ///
-    /// This method cannot fail. A value from the tolerant reader may hold
-    /// `-0.0`, `NaN`, or a disallowed tag; for those values the encoding
-    /// silently writes nothing. Use [`Self::try_to_canonical_bytes`] for
-    /// untrusted input so the failure is visible.
-    pub fn to_canonical_bytes(&self) -> Vec<u8> {
-        let mut out = Vec::new();
-        self.encode(&mut out);
-        out
-    }
-
-    pub fn try_to_canonical_bytes(&self) -> Result<Vec<u8>, CborError> {
+    /// Returns a [`CborError`] when encountering disallowed values (such as `-0.0`, `NaN`, or
+    /// disallowed tags).
+    pub fn to_canonical_bytes(&self) -> Result<Vec<u8>, CborError> {
         let mut out = Vec::new();
         self.try_encode(&mut out)?;
         Ok(out)
     }
 
+    /// Explicit alias for [`Self::to_canonical_bytes`].
+    pub fn try_to_canonical_bytes(&self) -> Result<Vec<u8>, CborError> {
+        self.to_canonical_bytes()
+    }
+
     /// Encodes this value into the output byte buffer.
-    ///
-    /// On error nothing is written to the buffer. Values from the canonical
-    /// path always encode. Values from the tolerant reader can fail when they
-    /// hold `-0.0`, `NaN`, or a disallowed tag.
-    pub fn encode(&self, out: &mut Vec<u8>) {
-        let start = out.len();
-        if self.try_encode(out).is_err() {
-            out.truncate(start);
-        }
+    pub fn encode(&self, out: &mut Vec<u8>) -> Result<(), CborError> {
+        self.try_encode(out)
     }
 
     /// Encodes this value into the output byte buffer, reporting the error.

--- a/crates/ledger-format/src/entry.rs
+++ b/crates/ledger-format/src/entry.rs
@@ -134,6 +134,22 @@ impl EntryKind {
     }
 }
 
+impl TryFrom<u64> for EntryKind {
+    type Error = u64;
+
+    fn try_from(tag: u64) -> Result<Self, Self::Error> {
+        Self::from_tag(tag).ok_or(tag)
+    }
+}
+
+impl TryFrom<u32> for EntryKind {
+    type Error = u32;
+
+    fn try_from(tag: u32) -> Result<Self, Self::Error> {
+        Self::from_tag(tag as u64).ok_or(tag)
+    }
+}
+
 /// Message identity: sender actor and the sender entry sequence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MessageId {

--- a/crates/ledger-format/tests/cbor_conformance.rs
+++ b/crates/ledger-format/tests/cbor_conformance.rs
@@ -12,7 +12,7 @@ fn cbor_enforces_canonical_key_sorting() {
     ];
 
     let val = CborValue::Map(map_items);
-    let bytes = val.to_canonical_bytes();
+    let bytes = val.to_canonical_bytes().unwrap();
 
     let decoded = CborValue::from_canonical_bytes(&bytes).unwrap();
     if let CborValue::Map(entries) = decoded {
@@ -68,7 +68,7 @@ fn cbor_round_trips_nested_structures() {
         CborValue::Null,
     ]);
 
-    let bytes = val.to_canonical_bytes();
+    let bytes = val.to_canonical_bytes().unwrap();
     let decoded = CborValue::from_canonical_bytes(&bytes).unwrap();
     assert_eq!(val, decoded);
 }
@@ -181,7 +181,7 @@ fn floats_reject_non_canonical() {
 }
 
 #[test]
-fn all_half_precision_patterns_round_trip() {
+fn all_f16_bit_patterns_either_roundtrip_or_reject() {
     // Every f16 bit pattern must either decode to a canonical float that
     // re-encodes to the same bytes, or be rejected as -0.0 / NaN. This guards
     // the manual half-precision conversion against regressions.
@@ -189,7 +189,7 @@ fn all_half_precision_patterns_round_trip() {
         let bytes = [0xf9, (bits >> 8) as u8, bits as u8];
         match CborValue::from_canonical_bytes(&bytes) {
             Ok(value) => {
-                let reencoded = value.to_canonical_bytes();
+                let reencoded = value.to_canonical_bytes().unwrap();
                 assert_eq!(reencoded, bytes.to_vec(), "f16 pattern {bits:#06x}");
             }
             Err(CborError::NonCanonicalFloat) => {}

--- a/crates/ledger-format/tests/conformance.rs
+++ b/crates/ledger-format/tests/conformance.rs
@@ -317,7 +317,7 @@ fn golden_fixtures_round_trip_identity() {
         let bytes = hex_bytes(&raw);
         let decoded = CborValue::from_canonical_bytes(&bytes)
             .unwrap_or_else(|err| panic!("fixture {} must decode: {err:?}", path.display()));
-        let reencoded = decoded.to_canonical_bytes();
+        let reencoded = decoded.to_canonical_bytes().unwrap();
         assert_eq!(
             reencoded,
             bytes,
@@ -365,7 +365,7 @@ fn golden_fixture_semantic_expectations() {
                     "semantic mismatch for {}",
                     path.display()
                 );
-                let reencoded = expected.to_canonical_bytes();
+                let reencoded = expected.to_canonical_bytes().unwrap();
                 assert_eq!(
                     reencoded,
                     bytes,

--- a/crates/ledger-format/tests/fuzz_mutation.rs
+++ b/crates/ledger-format/tests/fuzz_mutation.rs
@@ -149,7 +149,7 @@ fn seed_corpus() -> Vec<Vec<u8>> {
         CborValue::Bytes(vec![0xde, 0xad, 0xbe, 0xef]),
         CborValue::Float(1.5),
     ]);
-    corpus.push(nested.to_canonical_bytes());
+    corpus.push(nested.to_canonical_bytes().unwrap());
 
     corpus
 }

--- a/crates/ledger-journal/src/dag.rs
+++ b/crates/ledger-journal/src/dag.rs
@@ -18,6 +18,7 @@ use ledger_format::{ActorId, EntryData, EntryKind, EntryPayload, Hash};
 const OVERLAY_THRESHOLD: usize = 1024;
 
 /// Error returned when a journal invariant is violated.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum JournalError {
     /// A referenced parent is not present in the journal.

--- a/crates/ledger-sim/src/net.rs
+++ b/crates/ledger-sim/src/net.rs
@@ -348,14 +348,19 @@ impl SimNet {
             .map(|(index, _)| index)
             .collect();
         let first = *ready.first()?;
-        let window = self.effective_reorder_window(self.queue[first].from, task);
+        let sender = self.queue[first].from;
+        let window = self.effective_reorder_window(sender, task);
+        let link_candidates: Vec<usize> = ready
+            .into_iter()
+            .filter(|&idx| self.queue[idx].from == sender)
+            .collect();
         let index = if window == 0 {
             first
         } else {
             // The exact bounded candidate window: the last `window` ready
-            // messages, newest-first within it.
-            let start = ready.len().saturating_sub(window);
-            ready[ready.len() - 1].max(ready[start])
+            // messages for this link, newest-first within it.
+            let start = link_candidates.len().saturating_sub(window);
+            link_candidates[link_candidates.len() - 1].max(link_candidates[start])
         };
         self.queue.remove(index)
     }
@@ -365,7 +370,7 @@ impl SimNet {
     ///
     /// Window zero draws nothing and serves the queue head (FIFO). A nonzero
     /// window limits the candidate set to the last `window` ready messages
-    /// and serves `candidate[draw(candidate.len())]`.
+    /// on this link and serves `candidate[draw(candidate.len())]`.
     pub fn recv_at_drawn(
         &mut self,
         task: usize,
@@ -380,12 +385,17 @@ impl SimNet {
             .map(|(index, _)| index)
             .collect();
         let first = *ready.first()?;
-        let window = self.effective_reorder_window(self.queue[first].from, task);
+        let sender = self.queue[first].from;
+        let window = self.effective_reorder_window(sender, task);
+        let link_candidates: Vec<usize> = ready
+            .into_iter()
+            .filter(|&idx| self.queue[idx].from == sender)
+            .collect();
         let index = if window == 0 {
             first
         } else {
-            let start = ready.len().saturating_sub(window);
-            let suffix = &ready[start..];
+            let start = link_candidates.len().saturating_sub(window);
+            let suffix = &link_candidates[start..];
             suffix[(draw(suffix.len() as u64) % suffix.len() as u64) as usize]
         };
         self.queue.remove(index)

--- a/crates/ledger-worker/src/queue/mod.rs
+++ b/crates/ledger-worker/src/queue/mod.rs
@@ -22,6 +22,7 @@ pub const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 ///
 /// `Queued` and `Leased` are transient; `Failed`, `Cancelled`, and `Done`
 /// are terminal. Terminal tasks never re-enter the queue.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskStatus {
     /// Waiting in the queue for a worker lease.

--- a/crates/ledger-worker/src/transport.rs
+++ b/crates/ledger-worker/src/transport.rs
@@ -215,6 +215,7 @@ pub async fn run_assigned_task(
     heartbeat: Duration,
 ) -> Result<TaskOutcome, SessionError> {
     let task_id = task.id.clone();
+    let attempts = task.attempts;
     let mut exec = tokio::task::spawn_blocking(move || execute_task(task));
     let mut ticker = tokio::time::interval(heartbeat.max(Duration::from_millis(1)));
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -225,7 +226,7 @@ pub async fn run_assigned_task(
         message: Some(session_request::Message::Heartbeat(Heartbeat {
             worker_id: worker_id.to_string(),
             task_id: task_id.clone(),
-            attempts: 0,
+            attempts,
         })),
     };
     if tx.send(hello_hb).await.is_err() {
@@ -239,7 +240,7 @@ pub async fn run_assigned_task(
                     message: Some(session_request::Message::Heartbeat(Heartbeat {
                         worker_id: worker_id.to_string(),
                         task_id: task_id.clone(),
-                        attempts: 0,
+                        attempts,
                     })),
                 };
                 if tx.send(msg).await.is_err() {

--- a/crates/ledger-worker/src/worker.rs
+++ b/crates/ledger-worker/src/worker.rs
@@ -68,6 +68,7 @@ pub struct WorkerResult {
 }
 
 /// Errors from worker execution.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum WorkerError {
     /// The queued run_config hash did not match the recomputed canonical

--- a/crates/rt-server/src/main.rs
+++ b/crates/rt-server/src/main.rs
@@ -26,11 +26,15 @@ fn main() -> ExitCode {
             }
             "--seed" => {
                 i += 1;
-                if let Some(hex) = args.get(i)
-                    && let Some(bytes) = decode_hex(hex)
-                {
-                    seed = bytes;
-                }
+                let Some(hex) = args.get(i) else {
+                    eprintln!("rt-server: missing argument for --seed");
+                    return ExitCode::from(2);
+                };
+                let Some(bytes) = decode_hex(hex) else {
+                    eprintln!("rt-server: invalid 64-hex seed: {hex}");
+                    return ExitCode::from(2);
+                };
+                seed = bytes;
             }
             _ => {}
         }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "xtask"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 publish = false
 description = "Workspace automation: license gate, onboarding doctor"
 
 [dependencies]
+
+[lints]
+workspace = true


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the codebase, focusing on enhanced async runtime synchronization, improved error handling, and API ergonomics. Notably, it adds async notification primitives to the runtime, makes serialization APIs more robust, and introduces `#[non_exhaustive]` to key enums for better forward compatibility. There are also targeted test improvements and code simplifications.

**Runtime and Synchronization Improvements:**
- Added a `tokio::sync::Notify` primitive to `SharedNetwork` in `ldgr-rt` and updated message receive logic to use async notification instead of polling, improving efficiency and correctness. (`crates/ldgr-rt/src/net.rs`, `crates/ldgr-rt/Cargo.toml`) [[1]](diffhunk://#diff-8fe729ee944cb7755fd21631815358432be8fe1871f88990f2a5a622f6b9d034R71-R72) [[2]](diffhunk://#diff-8fe729ee944cb7755fd21631815358432be8fe1871f88990f2a5a622f6b9d034R138-R150) F0640addL593R594, [[3]](diffhunk://#diff-08f15f36c49ee59683a30d34c07a84909f5d8c2e047526714db3e79ad75e7fbfL3-R5) [[4]](diffhunk://#diff-08f15f36c49ee59683a30d34c07a84909f5d8c2e047526714db3e79ad75e7fbfL17-R17)

**API and Error Handling Enhancements:**
- Changed `CborValue::to_canonical_bytes` and related methods to return a `Result` with a proper error type instead of silently failing, and updated all usages in tests and fuzzing to handle this. (`crates/ledger-format/src/cbor/encode.rs`, `crates/ledger-format/tests/cbor_conformance.rs`, `crates/ledger-format/tests/conformance.rs`, `crates/ledger-format/tests/fuzz_mutation.rs`) [[1]](diffhunk://#diff-1618f707b22393b381817a0cf3184ac416d84d44747c59928a3d75dfe43eb31cL8-R23) [[2]](diffhunk://#diff-702b2dd108cb36b4aeb3333935cee47eca61fecc983ad07460e74f35227d17aeL15-R15) [[3]](diffhunk://#diff-702b2dd108cb36b4aeb3333935cee47eca61fecc983ad07460e74f35227d17aeL71-R71) [[4]](diffhunk://#diff-702b2dd108cb36b4aeb3333935cee47eca61fecc983ad07460e74f35227d17aeL184-R192) [[5]](diffhunk://#diff-417600174f4ad6495c397d767bedfa4aaaa05feb095871b0cf46babb43d6081aL320-R320) [[6]](diffhunk://#diff-417600174f4ad6495c397d767bedfa4aaaa05feb095871b0cf46babb43d6081aL368-R368) [[7]](diffhunk://#diff-f2b799273328a6bc8de4af798d037c4759a2fba2281390cf82b95145465b461aL152-R152)

**Enum Extensibility:**
- Marked several public enums as `#[non_exhaustive]` to allow for future expansion without breaking changes, including `RunCompletion`, `JournalError`, and `TaskStatus`. (`crates/ldgr-rt/src/runtime.rs`, `crates/ledger-journal/src/dag.rs`, `crates/ledger-worker/src/queue/mod.rs`) [[1]](diffhunk://#diff-67831c90f9abac4eb63f6dadb1e21d7da8199b2fc33b7c0021a0dc9ff4a2df2dR161) [[2]](diffhunk://#diff-ddde1eaf3184c2fd6d5348d4f7a0e61da9c0ad46787bca523e8d97dd601212deR21) [[3]](diffhunk://#diff-f885ef5e535bf15d561d3e946adf13fdb8feac090ea00be7bd208047bdd852e5R25)

**Async Workflow Execution:**
- Added an async variant `resume_async` to `WorkflowExecution` for executing workflow steps with asynchronous executors, along with a comprehensive test. (`crates/ledger-flow/src/workflow.rs`, `crates/ledger-flow/src/lib.rs`) [[1]](diffhunk://#diff-9244d9181c83bf4046fa3279ac314424a58a28d31ec5eb23ce03dbc6844dd3f0R272-R327) [[2]](diffhunk://#diff-072e915852add062dcbff082511d01e430dc4e6c664e9d123bb178c22cc0984bR469-R501)

**Code Simplification and Robustness:**
- Refactored `EntryKind` to implement `TryFrom<u64>` and `TryFrom<u32>`, and updated adapters to use this for more robust tag parsing. (`crates/ledger-format/src/entry.rs`, `crates/ledger-adapters/src/envelope.rs`) [[1]](diffhunk://#diff-3141b30df42025fbe53e5a8983dff59a1e9be5fb4f1ba481820aeb8c4f8948f4R137-R152) [[2]](diffhunk://#diff-4505de43e10824eebc81cd79a8e286017f6dd8da0a8aa7ba9a38ece2e9735b9fL271-R271)
- Improved message reordering logic in `SimNet` to ensure windowing is per-link, not global, which fixes subtle simulation bugs. (`crates/ledger-sim/src/net.rs`) [[1]](diffhunk://#diff-25a01377cc0858f46a576b46a4f86ea5d177a838e50f8a24d76ba7ab8c74fe49L351-R363) [[2]](diffhunk://#diff-25a01377cc0858f46a576b46a4f86ea5d177a838e50f8a24d76ba7ab8c74fe49L368-R373) [[3]](diffhunk://#diff-25a01377cc0858f46a576b46a4f86ea5d177a838e50f8a24d76ba7ab8c74fe49L383-R398)
- Updated Cargo.toml files to use workspace settings for version, edition, and rust-version for consistency. (`crates/ldgr-rt/Cargo.toml`, `crates/ledger-adapters/Cargo.toml`) [[1]](diffhunk://#diff-08f15f36c49ee59683a30d34c07a84909f5d8c2e047526714db3e79ad75e7fbfL3-R5) [[2]](diffhunk://#diff-5390484ad5baa6e629df227ea436bc6ebd6636de01d486d90915b06639f7e1a7L3-R5)

Test improvements and minor refactorings were also made to ensure code correctness and maintainability.